### PR TITLE
Feat/9 버튼 컴포넌트 구현

### DIFF
--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -3,6 +3,21 @@
 import cn from '@/lib/utils';
 import { ButtonProps } from './types';
 
+/**
+ * 공통 Button 컴포넌트입니다.
+ * variant와 selected 값을 기반으로 버튼 스타일을 조절할 수 있습니다.
+ *
+ * @component
+ *
+ * @param {ButtonProps} props - 버튼에 전달되는 props
+ * @param {'primary' | 'secondary' | 'category'} props.variant - 버튼 스타일 종류
+ * @param {boolean} [props.selected] - category 타입 버튼에서 선택 여부 (선택적)
+ * @param {string} [props.className] - 외부에서 전달하는 커스텀 클래스
+ * @param {React.ReactNode} props.children - 버튼 내부에 렌더링할 요소
+ * @param {string} [props.type='button'] - 버튼의 HTML 타입
+ * @returns {JSX.Element} 버튼 JSX
+ */
+
 export default function Button({
   type = 'button',
   className = '',

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -19,7 +19,7 @@ export default function Button({
   type = 'button',
   className = '',
   children,
-  variant = 'primary',
+  variant,
   selected,
   ...props
 }: ButtonProps) {

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -13,9 +13,6 @@ import { ButtonProps } from './types';
  * @param {'primary' | 'secondary' | 'category'} props.variant - 버튼 스타일 종류
  * @param {boolean} [props.selected] - category 타입 버튼에서 선택 여부 (선택적)
  * @param {string} [props.className] - 외부에서 전달하는 커스텀 클래스
- * @param {React.ReactNode} props.children - 버튼 내부에 렌더링할 요소
- * @param {string} [props.type='button'] - 버튼의 HTML 타입
- * @returns {JSX.Element} 버튼 JSX
  */
 
 export default function Button({

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import cn from '@/lib/utils';
+import { ButtonProps } from './types';
+
+export default function Button({
+  type = 'button',
+  className = '',
+  children,
+  variant = 'primary',
+  selected,
+  ...props
+}: ButtonProps) {
+  const variantClass: Record<ButtonProps['variant'], string> = {
+    primary: 'bg-nomad text-white',
+    secondary: 'bg-white border border-nomad text-nomad',
+    category: 'bg-white border border-green-300 text-green-300',
+  };
+
+  const selectedClass =
+    variant === 'category' && selected ? 'bg-green-300 text-white' : '';
+
+  return (
+    <button
+      type={type}
+      className={cn(
+        'w-full disabled:border-none disabled:bg-gray-600 disabled:text-white',
+        variantClass[variant],
+        selectedClass,
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/button/types.ts
+++ b/src/components/button/types.ts
@@ -1,6 +1,21 @@
 import { ButtonHTMLAttributes } from 'react';
 
+/**
+ * Button 컴포넌트에서 사용할 수 있는 버튼 스타일 종류입니다.
+ * - 'primary': 배경색이 있는 기본 버튼
+ * - 'secondary': 배경색이 없는 기본 버튼
+ * - 'category': 필터나 탭 등 선택 가능한 버튼
+ */
+
 type Variant = 'primary' | 'secondary' | 'category';
+
+/**
+ * Button 컴포넌트의 props 정의입니다.
+ *
+ * @property variant - 버튼의 스타일 종류
+ * @property selected - 'category' 타입 버튼에서 선택 여부 (선택적 사용)
+ * @extends ButtonHTMLAttributes<HTMLButtonElement> - 기본 HTML 버튼 속성 모두 포함
+ */
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant: Variant;

--- a/src/components/button/types.ts
+++ b/src/components/button/types.ts
@@ -1,0 +1,8 @@
+import { ButtonHTMLAttributes } from 'react';
+
+type Variant = 'primary' | 'secondary' | 'category';
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant: Variant;
+  selected?: boolean;
+}


### PR DESCRIPTION
## 📌 변경 사항 개요

버튼 공통 컴포넌트 구현

## 📝 상세 내용
primary, secondary, category 스타일 종류를 3가지로 나눠서 원하는 스타일을 적용할 수 있게 했습니다.
selected되면 category에 스타일이 바뀌게 적용했습니다.
피그마상 폰트사이즈나 굵기, 버튼의 높이, radius가 다 달라서 className으로 부모에서 정할 수 있게 했습니다. 이부분은 꼭 참고하셔서 구현사항 대로 적용하시길 바라겠습니다!


## 🔗 관련 이슈

- #9 

## 🖼️ 스크린샷(선택사항)
<img width="897" height="95" alt="image" src="https://github.com/user-attachments/assets/19fb9192-c4ae-41dc-8e80-cdd116f560c3" />


## 💡 참고 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **New Features**
  * 다양한 스타일과 선택 상태를 지원하는 재사용 가능한 버튼 컴포넌트가 추가되었습니다.  
  * 버튼은 'primary', 'secondary', 'category' 스타일을 선택할 수 있으며, 'category' 스타일에서는 선택 여부 표시가 가능합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->