### PR TITLE
Fix/65 CD 파이프라인 헬스 체크 오류 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -134,7 +134,7 @@ jobs:
             # 헬스 체크
             echo "❤️ Health check..."
             for i in {1..30}; do
-              if curl -f http://localhost:3000 > /dev/null 2>&1; then
+              if curl -f http://localhost > /dev/null 2>&1; then
                 echo "✅ Service is healthy!"
                 break
               fi
@@ -143,9 +143,10 @@ jobs:
             done
             
             # 최종 확인
-            if ! curl -f http://localhost:3000 > /dev/null 2>&1; then
+            if ! curl -f http://localhost > /dev/null 2>&1; then
               echo "❌ Service health check failed after 60 seconds!"
               docker compose logs --tail 50 nextjs
+              docker compose logs --tail 50 nginx
               exit 1
             fi
             


### PR DESCRIPTION
## 📌 변경 사항 개요
https://github.com/codeit-2team/GlobalNomad/pull/63 브랜치를 머지한 후, deploy.yml 워크플로우의 deploy 잡이 헬스 체크(Health Check) 단계에서 실패했습니다.

로그 확인 결과, 헬스 체크 스크립트가 curl -f [http://localhost:3000을](http://localhost:3000%EC%9D%84/) 호출하여 Next.js 컨테이너에 직접 접근하려고 시도했으나, 보안상의 이유로 3000번 포트는 외부에 노출되어 있지 않아 연결이 거부되었습니다.
<!-- 이 PR에서 수행한 변경 사항에 대한 간략한 설명 -->

## 📝 상세 내용
헬스 체크 경로를 실제 사용자 접근 경로와 동일하게 Nginx를 통하도록 curl -f http://localhost로 변경
<!-- 구현 내용에 대한 자세한 설명 -->

## 🔗 관련 이슈
- Resolves: #65 
<!-- 관련된 이슈 번호 (예: Resolves: #123) -->

## 🖼️ 스크린샷(선택사항)

<!-- UI 변경이 있는 경우 변경 전/후 스크린샷 -->

## 💡 참고 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 배포 스크립트의 헬스 체크 URL이 `http://localhost:3000`에서 `http://localhost`로 변경되었습니다.
  * 최종 헬스 체크 실패 시, 기존 `nextjs` 컨테이너 로그와 함께 `nginx` 컨테이너 로그도 출력됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->