### PR TITLE
Feat/45-2 메인페이지 인기 체험 섹션 UI 구현

### DIFF
--- a/src/app/(with-header)/components/BannerSection.tsx
+++ b/src/app/(with-header)/components/BannerSection.tsx
@@ -17,7 +17,7 @@ export default function BannerSection() {
       <div className='absolute inset-0 bg-gradient-to-r from-black to-transparent' />
 
       {/* 텍스트 콘텐츠 */}
-      <div className='relative z-10 flex flex-col items-start w-220 max-w-1152 md:w-440 lg:w-full pl-24 pt-74 md:pl-32 lg:pl-0 md:pt-144 lg:pt-159 lg:ml-auto lg:mr-auto gap-8 lg:gap-20 h-full text-white font-bold break-keep'>
+      <div className='relative z-10 flex flex-col items-start w-220 max-w-1200 md:w-440 lg:w-full pl-24 pt-74 md:pl-32 lg:pl-0 md:pt-144 lg:pt-159 lg:ml-auto lg:mr-auto gap-8 lg:gap-20 h-full text-white font-bold break-keep'>
         <h2 className='text-2xl md:text-[54px] md:leading-[64px] lg:text-[68px] lg:leading-[78px]'>
           함께 배우면 즐거운<br />
           스트릿 댄스

--- a/src/app/(with-header)/components/ExperienceCard.tsx
+++ b/src/app/(with-header)/components/ExperienceCard.tsx
@@ -2,24 +2,24 @@ import Image from 'next/image';
 
 export default function ExperienceCard() {
   return (
-    <div className="relative w-186 h-186 md:w-384 md:h-384 rounded-[20px] overflow-hidden shadow-md bg-white">
+    <div className='relative w-186 h-186 md:w-384 md:h-384 rounded-[20px] overflow-hidden shadow-md bg-white'>
       {/* 배경 이미지 */}
       <Image
-        src="/test/image1.png"
-        alt="체험 이미지"
-        className="w-full object-cover"
+        src='/test/image1.png'
+        alt='체험 이미지'
+        className='w-full object-cover'
         fill
       />
       {/* 어두운 오버레이 */}
       <div className='absolute inset-0 bg-gradient-to-r from-black to-transparent' />
       {/* 텍스트 정보 블록 (카드 하단 위치 고정) */}
-      <div className="absolute bottom-12 flex flex-col gap-6 md:gap-20 px-20 py-12 text-white">
+      <div className='absolute bottom-12 flex flex-col gap-6 md:gap-20 px-20 py-12 text-white'>
         {/* 별점 정보 */}
-        <span className="text-md">⭐ 4.9 (293)</span>
+        <span className='text-md'>⭐ 4.9 (293)</span>
         {/* 체험명 (줄바꿈 포함, 반응형 크기) */}
-        <p className="text-2lg md:text-3xl font-semibold">함께 배우면 즐거운<br />스트릿 댄스</p>
+        <p className='text-2lg md:text-3xl font-semibold'>함께 배우면 즐거운<br />스트릿 댄스</p>
         {/* 가격 정보 */}
-        <p className="text-lg md:text-xl">₩ 38,000 <span className="text-gray-600 text-md">/ 인</span></p>
+        <p className='text-lg md:text-xl'>₩ 38,000 <span className='text-gray-600 text-md'>/ 인</span></p>
       </div>
     </div>
   );

--- a/src/app/(with-header)/components/ExperienceCard.tsx
+++ b/src/app/(with-header)/components/ExperienceCard.tsx
@@ -1,0 +1,15 @@
+export default function ExperienceCard() {
+  return (
+    <div className="rounded-xl overflow-hidden shadow-md bg-white">
+      <img
+        src="/img/experience1.jpg"
+        alt="체험 이미지"
+        className="w-full h-48 object-cover"
+      />
+      <div className="p-4">
+        <h3 className="text-lg font-semibold">강릉 서핑 클래스</h3>
+        <p className="text-sm text-gray-600">강원도 강릉시 · ₩35,000</p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(with-header)/components/ExperienceCard.tsx
+++ b/src/app/(with-header)/components/ExperienceCard.tsx
@@ -1,14 +1,20 @@
+import Image from 'next/image';
+
 export default function ExperienceCard() {
   return (
-    <div className="rounded-xl overflow-hidden shadow-md bg-white">
-      <img
-        src="/img/experience1.jpg"
+    <div className="relative w-186 h-186 md:w-384 md:h-384 rounded-[20px] overflow-hidden shadow-md bg-white">
+      <Image
+        src="/test/image1.png"
         alt="체험 이미지"
-        className="w-full h-48 object-cover"
+        className="w-full object-cover"
+        fill
       />
-      <div className="p-4">
-        <h3 className="text-lg font-semibold">강릉 서핑 클래스</h3>
-        <p className="text-sm text-gray-600">강원도 강릉시 · ₩35,000</p>
+      {/* 어두운 오버레이 */}
+      <div className='absolute inset-0 bg-gradient-to-r from-black to-transparent' />
+      <div className="absolute bottom-12 flex flex-col gap-6 md:gap-20 px-20 py-12 text-white">
+        <span className="text-md">⭐ 4.9 (293)</span>
+        <p className="text-2lg md:text-3xl font-semibold">함께 배우면 즐거운<br />스트릿 댄스</p>
+        <p className="text-lg md:text-xl">₩ 38,000 <span className="text-gray-600 text-md">/ 인</span></p>
       </div>
     </div>
   );

--- a/src/app/(with-header)/components/ExperienceCard.tsx
+++ b/src/app/(with-header)/components/ExperienceCard.tsx
@@ -3,6 +3,7 @@ import Image from 'next/image';
 export default function ExperienceCard() {
   return (
     <div className="relative w-186 h-186 md:w-384 md:h-384 rounded-[20px] overflow-hidden shadow-md bg-white">
+      {/* 배경 이미지 */}
       <Image
         src="/test/image1.png"
         alt="체험 이미지"
@@ -11,9 +12,13 @@ export default function ExperienceCard() {
       />
       {/* 어두운 오버레이 */}
       <div className='absolute inset-0 bg-gradient-to-r from-black to-transparent' />
+      {/* 텍스트 정보 블록 (카드 하단 위치 고정) */}
       <div className="absolute bottom-12 flex flex-col gap-6 md:gap-20 px-20 py-12 text-white">
+        {/* 별점 정보 */}
         <span className="text-md">⭐ 4.9 (293)</span>
+        {/* 체험명 (줄바꿈 포함, 반응형 크기) */}
         <p className="text-2lg md:text-3xl font-semibold">함께 배우면 즐거운<br />스트릿 댄스</p>
+        {/* 가격 정보 */}
         <p className="text-lg md:text-xl">₩ 38,000 <span className="text-gray-600 text-md">/ 인</span></p>
       </div>
     </div>

--- a/src/app/(with-header)/components/PopularExperiences.tsx
+++ b/src/app/(with-header)/components/PopularExperiences.tsx
@@ -1,15 +1,48 @@
 'use client';
 
+import { useRef } from 'react';
 import ExperienceCard from '@/app/(with-header)/components/ExperienceCard';
+import IconArrowRight from '@assets/svg/right-arrow';
+import IconArrowLeft from '@assets/svg/left-arrow';
 
 export default function PopularExperiences() {
+  const sliderRef = useRef<HTMLDivElement>(null);
+
+  const scrollByCard = (direction: 'left' | 'right') => {
+    if (!sliderRef.current) return;
+
+    const card = sliderRef.current.querySelector('.card');
+    if (!(card instanceof HTMLElement)) return;
+
+    const cardWidth = card.offsetWidth;
+    const gap = parseInt(getComputedStyle(sliderRef.current).gap) || 0;
+    const distance = cardWidth + gap;
+
+    sliderRef.current.scrollBy({
+      left: direction === 'left' ? -distance : distance,
+      behavior: 'smooth',
+    });
+  };
+
   return (
-    <section className="px-4 py-10">
-      <h2 className="text-2xl font-bold mb-6">🔥 인기 체험</h2>
-      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
-        <ExperienceCard />
-        <ExperienceCard />
-        <ExperienceCard />
+    <section className="pt-24 pl-24 pb-40">
+      <div className="flex justify-between items-center pb-16 md:pb-32 mb-6">
+        <h2 className="text-xl md:text-3xl font-bold">🔥 인기 체험</h2>
+        <div className="flex gap-2">
+          <IconArrowLeft onClick={() => scrollByCard('left')} className="text-2xl px-3" />
+          <IconArrowRight onClick={() => scrollByCard('right')} className="text-2xl px-3" />
+        </div>
+      </div>
+
+      <div
+        ref={sliderRef}
+        className="flex gap-16 md:gap-32 overflow-x-auto scroll-smooth no-scrollbar"
+      >
+        {[...Array(4)].map((_, idx) => (
+          <div key={idx} className="flex-shrink-0 card">
+            <ExperienceCard />
+          </div>
+        ))}
       </div>
     </section>
   );

--- a/src/app/(with-header)/components/PopularExperiences.tsx
+++ b/src/app/(with-header)/components/PopularExperiences.tsx
@@ -6,18 +6,22 @@ import IconArrowRight from '@assets/svg/right-arrow';
 import IconArrowLeft from '@assets/svg/left-arrow';
 
 export default function PopularExperiences() {
+  // 카드 슬라이더를 참조할 DOM ref
   const sliderRef = useRef<HTMLDivElement>(null);
 
+  // 좌우 버튼 클릭 시 한 장씩 슬라이드 이동
   const scrollByCard = (direction: 'left' | 'right') => {
     if (!sliderRef.current) return;
 
+    // 첫 번째 카드 요소를 찾아서 너비 측정
     const card = sliderRef.current.querySelector('.card');
     if (!(card instanceof HTMLElement)) return;
 
-    const cardWidth = card.offsetWidth;
-    const gap = parseInt(getComputedStyle(sliderRef.current).gap) || 0;
-    const distance = cardWidth + gap;
+    const cardWidth = card.offsetWidth; // 카드 너비
+    const gap = parseInt(getComputedStyle(sliderRef.current).gap) || 0; // gap 값
+    const distance = cardWidth + gap; // 한 번에 이동할 거리
 
+    // 슬라이더 스크롤 이동 (좌/우 방향에 따라)
     sliderRef.current.scrollBy({
       left: direction === 'left' ? -distance : distance,
       behavior: 'smooth',
@@ -26,6 +30,7 @@ export default function PopularExperiences() {
 
   return (
     <section className="pt-24 md:pt-34 pl-24 lg:pl-0 pb-40 lg:pb-33 lg:max-w-1200 lg:w-full mx-auto">
+      {/* 섹션 제목 + 좌우 화살표 버튼 */}
       <div className="flex justify-between items-center pb-16 md:pb-32 mb-6">
         <h2 className="text-xl md:text-3xl font-bold">🔥 인기 체험</h2>
         <div className="flex gap-2">
@@ -34,11 +39,13 @@ export default function PopularExperiences() {
         </div>
       </div>
 
+      {/* 가로 슬라이드 카드 리스트 */}
       <div
         ref={sliderRef}
         className="flex gap-16 md:gap-32 lg:gap-24 overflow-x-auto scroll-smooth no-scrollbar"
       >
         {[...Array(4)].map((_, idx) => (
+          // 카드 wrapper: flex-shrink-0으로 크기 고정 + 'card' 클래스로 식별
           <div key={idx} className="flex-shrink-0 card">
             <ExperienceCard />
           </div>

--- a/src/app/(with-header)/components/PopularExperiences.tsx
+++ b/src/app/(with-header)/components/PopularExperiences.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import ExperienceCard from '@/app/(with-header)/components/ExperienceCard';
+
+export default function PopularExperiences() {
+  return (
+    <section className="px-4 py-10">
+      <h2 className="text-2xl font-bold mb-6">🔥 인기 체험</h2>
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
+        <ExperienceCard />
+        <ExperienceCard />
+        <ExperienceCard />
+      </div>
+    </section>
+  );
+}

--- a/src/app/(with-header)/components/PopularExperiences.tsx
+++ b/src/app/(with-header)/components/PopularExperiences.tsx
@@ -25,18 +25,18 @@ export default function PopularExperiences() {
   };
 
   return (
-    <section className="pt-24 pl-24 pb-40">
+    <section className="pt-24 md:pt-34 pl-24 lg:pl-0 pb-40 lg:pb-33 lg:max-w-1200 lg:w-full mx-auto">
       <div className="flex justify-between items-center pb-16 md:pb-32 mb-6">
         <h2 className="text-xl md:text-3xl font-bold">🔥 인기 체험</h2>
         <div className="flex gap-2">
-          <IconArrowLeft onClick={() => scrollByCard('left')} className="text-2xl px-3" />
-          <IconArrowRight onClick={() => scrollByCard('right')} className="text-2xl px-3" />
+          <IconArrowLeft size={32} onClick={() => scrollByCard('left')} className="text-2xl px-3" />
+          <IconArrowRight size={32} onClick={() => scrollByCard('right')} className="text-2xl px-3" />
         </div>
       </div>
 
       <div
         ref={sliderRef}
-        className="flex gap-16 md:gap-32 overflow-x-auto scroll-smooth no-scrollbar"
+        className="flex gap-16 md:gap-32 lg:gap-24 overflow-x-auto scroll-smooth no-scrollbar"
       >
         {[...Array(4)].map((_, idx) => (
           <div key={idx} className="flex-shrink-0 card">

--- a/src/app/(with-header)/components/PopularExperiences.tsx
+++ b/src/app/(with-header)/components/PopularExperiences.tsx
@@ -29,24 +29,24 @@ export default function PopularExperiences() {
   };
 
   return (
-    <section className="pt-24 md:pt-34 pl-24 lg:pl-0 pb-40 lg:pb-33 lg:max-w-1200 lg:w-full mx-auto">
+    <section className='pt-24 md:pt-34 pl-24 lg:pl-0 pb-40 lg:pb-33 lg:max-w-1200 lg:w-full mx-auto'>
       {/* 섹션 제목 + 좌우 화살표 버튼 */}
-      <div className="flex justify-between items-center pb-16 md:pb-32 mb-6">
-        <h2 className="text-xl md:text-3xl font-bold">🔥 인기 체험</h2>
-        <div className="flex gap-2">
-          <IconArrowLeft size={32} onClick={() => scrollByCard('left')} className="text-2xl px-3" />
-          <IconArrowRight size={32} onClick={() => scrollByCard('right')} className="text-2xl px-3" />
+      <div className='flex justify-between items-center pb-16 md:pb-32 mb-6'>
+        <h2 className='text-xl md:text-3xl font-bold'>🔥 인기 체험</h2>
+        <div className='flex gap-2'>
+          <IconArrowLeft size={32} onClick={() => scrollByCard('left')} className='text-2xl px-3' />
+          <IconArrowRight size={32} onClick={() => scrollByCard('right')} className='text-2xl px-3' />
         </div>
       </div>
 
       {/* 가로 슬라이드 카드 리스트 */}
       <div
         ref={sliderRef}
-        className="flex gap-16 md:gap-32 lg:gap-24 overflow-x-auto scroll-smooth no-scrollbar"
+        className='flex gap-16 md:gap-32 lg:gap-24 overflow-x-auto scroll-smooth no-scrollbar'
       >
         {[...Array(4)].map((_, idx) => (
           // 카드 wrapper: flex-shrink-0으로 크기 고정 + 'card' 클래스로 식별
-          <div key={idx} className="flex-shrink-0 card">
+          <div key={idx} className='flex-shrink-0 card'>
             <ExperienceCard />
           </div>
         ))}

--- a/src/app/(with-header)/components/SearchBar.tsx
+++ b/src/app/(with-header)/components/SearchBar.tsx
@@ -13,7 +13,7 @@ export default function SearchBar() {
   };
 
   return (
-    <section className='flex lg:w-full lg:max-w-1152 lg:ml-auto lg:mr-auto justify-center px-16 lg:px-0'>
+    <section className='flex lg:w-full lg:max-w-1200 lg:ml-auto lg:mr-auto justify-center px-16 lg:px-0'>
       <div className='flex flex-col w-full gap-15 md:gap-32 px-24 py-16 md:px-24 md:py-32 rounded-[16px] bg-white shadow-md'>
         <div className='flex items-start gap-2 mb-4'>
           <h3 className='text-lg md:text-xl font-bold text-left'>

--- a/src/app/(with-header)/page.tsx
+++ b/src/app/(with-header)/page.tsx
@@ -1,9 +1,11 @@
 import BannerSection from '@/app/(with-header)/components/BannerSection';
+import PopularExperiences from '@/app/(with-header)/components/PopularExperiences';
 
 export default function HomePage() {
   return (
     <main>
       <BannerSection />
+      <PopularExperiences />
     </main>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -131,3 +131,11 @@
 
   --spacing: 0.0625rem;
 }
+
+.no-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+.no-scrollbar {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}


### PR DESCRIPTION
## 📌 변경 사항 개요

<!-- 이 PR에서 수행한 변경 사항에 대한 간략한 설명 -->
- 메인페이지 인기 체험 섹션 구현
- 라이브러리 없이 슬라이드 기능 직접 구현

## 📝 상세 내용

<!-- 구현 내용에 대한 자세한 설명 -->
- [x] 인기 체험 섹션 UI 및 레이아웃 구현
- [x] 카드 1장씩 슬라이드되는 캐러셀 기능 직접 구현
- [x] .no-scrollbar 클래스 추가로 스크롤바 숨김 처리

## 🔗 관련 이슈

<!-- 관련된 이슈 번호 (예: Resolves: #123) -->
- #45 

## 🖼️ 스크린샷(선택사항)

<!-- UI 변경이 있는 경우 변경 전/후 스크린샷 -->

https://github.com/user-attachments/assets/6ab6ec9f-596a-4c0a-8bc6-981830cacad5

## 💡 참고 사항
- 추후 API 연동 시 ExperienceCard를 props 기반으로 리팩토링 예정
- 현재는 더미 데이터 기준으로 4장 고정 렌더링 중

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 인기 체험(Experience) 카드를 가로 슬라이더 형태로 보여주는 "Popular Experiences" 섹션이 추가되었습니다.
  * 각 체험 카드는 이미지, 평점, 리뷰 수, 제목, 가격 정보를 제공합니다.

* **스타일**
  * 메인 배너와 검색바의 최대 너비가 1200픽셀로 확대되어 대형 화면에서 더 넓게 표시됩니다.
  * 스크롤바를 숨기는 새로운 CSS 유틸리티 클래스(.no-scrollbar)가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->