### PR TITLE
Feat/70 체험 등록/수정페이지 로직 및 레이아웃 1차 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "next": "15.3.5",
     "react": "^19.0.0",
     "react-datepicker": "^8.4.0",
+    "react-daum-postcode": "^3.2.0",
     "react-dom": "^19.0.0",
     "react-kakao-maps-sdk": "^1.2.0",
     "tailwind-merge": "^3.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       react-datepicker:
         specifier: ^8.4.0
         version: 8.4.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react-daum-postcode:
+        specifier: ^3.2.0
+        version: 3.2.0(react@19.1.0)
       react-dom:
         specifier: ^19.0.0
         version: 19.1.0(react@19.1.0)
@@ -1768,6 +1771,11 @@ packages:
     peerDependencies:
       react: ^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc
       react-dom: ^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc
+
+  react-daum-postcode@3.2.0:
+    resolution: {integrity: sha512-NHY8TUicZXMqykbKYT8kUo2PEU7xu1DFsdRmyWJrLEUY93Xhd3rEdoJ7vFqrvs+Grl9wIm9Byxh3bI+eZxepMQ==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   react-dom@19.1.0:
     resolution: {integrity: sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==}
@@ -3781,6 +3789,10 @@ snapshots:
       date-fns: 4.1.0
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
+
+  react-daum-postcode@3.2.0(react@19.1.0):
+    dependencies:
+      react: 19.1.0
 
   react-dom@19.1.0(react@19.1.0):
     dependencies:

--- a/src/app/(with-header)/myactivity/components/AddressInput.tsx
+++ b/src/app/(with-header)/myactivity/components/AddressInput.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import Modal from '@/components/Modal';
+import DaumPostcode from 'react-daum-postcode';
+import { useState } from 'react';
+import Input from '@/components/Input';
+import Button from '@/components/Button';
+
+interface AddressInputProps {
+  onAddressChange: (address: string) => void;
+  address: string;
+}
+
+export default function AddressInput({
+  onAddressChange,
+  address,
+}: AddressInputProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleComplete = (data: any) => {
+    let fullAddress = data.address;
+    let extraAddress = '';
+
+    if (data.addressType === 'R') {
+      if (data.bname !== '') {
+        extraAddress += data.bname;
+      }
+      if (data.buildingName !== '') {
+        extraAddress +=
+          extraAddress !== '' ? `, ${data.buildingName}` : data.buildingName;
+      }
+      fullAddress += extraAddress !== '' ? ` (${extraAddress})` : '';
+    }
+
+    onAddressChange(fullAddress);
+    setIsOpen(false);
+  };
+
+  return (
+    <div>
+      <Input
+        label='주소'
+        id='address'
+        value={address}
+        onClick={() => setIsOpen(true)}
+        readOnly
+      />
+      <Modal isOpen={isOpen} onOpenChange={setIsOpen}>
+        <Modal.Content>
+          <Modal.Header>
+            <Modal.Title>주소 검색</Modal.Title>
+            <Modal.Close />
+          </Modal.Header>
+          <Modal.Item>
+            <DaumPostcode onComplete={handleComplete} />
+          </Modal.Item>
+          <Modal.Footer>
+            <Button
+              variant='primary'
+              className='py-8'
+              onClick={() => setIsOpen(false)}
+            >
+              닫기
+            </Button>
+          </Modal.Footer>
+        </Modal.Content>
+      </Modal>
+    </div>
+  );
+}

--- a/src/app/(with-header)/myactivity/components/AddressInput.tsx
+++ b/src/app/(with-header)/myactivity/components/AddressInput.tsx
@@ -11,13 +11,22 @@ interface AddressInputProps {
   address: string;
 }
 
+interface PostcodeData {
+  address: string;
+  addressType: 'R' | 'J';
+  bname: string;
+  buildingName: string;
+  zonecode: string;
+  userSelectedType: string;
+}
+
 export default function AddressInput({
   onAddressChange,
   address,
 }: AddressInputProps) {
   const [isOpen, setIsOpen] = useState(false);
 
-  const handleComplete = (data: any) => {
+  const handleComplete = (data: PostcodeData) => {
     let fullAddress = data.address;
     let extraAddress = '';
 

--- a/src/app/(with-header)/myactivity/components/CategoryInput.tsx
+++ b/src/app/(with-header)/myactivity/components/CategoryInput.tsx
@@ -10,16 +10,13 @@ export default function CategoryInput({
 }: CategoryProps) {
   return (
     <div>
-      <label
-        htmlFor='category'
-        className='font-regular flex flex-col text-lg text-black'
-      >
+      <label className='font-regular flex flex-col text-lg text-black'>
         카테고리
       </label>
       <div>
         <select
-          id='category'
           className='w-full rounded-md border border-gray-800 bg-white px-20 py-17 placeholder-gray-600'
+          id='category'
           value={category}
           onChange={(e) => onCategoryChange(e.target.value)}
         >

--- a/src/app/(with-header)/myactivity/components/CategoryInput.tsx
+++ b/src/app/(with-header)/myactivity/components/CategoryInput.tsx
@@ -1,0 +1,37 @@
+interface CategoryProps {
+  category?: string;
+
+  onCategoryChange: (value: string) => void;
+}
+
+export default function CategoryInput({
+  category,
+  onCategoryChange,
+}: CategoryProps) {
+  return (
+    <div>
+      <label
+        htmlFor='category'
+        className='font-regular flex flex-col text-lg text-black'
+      >
+        카테고리
+      </label>
+      <div>
+        <select
+          id='category'
+          className='w-full rounded-md border border-gray-800 bg-white px-20 py-17 placeholder-gray-600'
+          value={category}
+          onChange={(e) => onCategoryChange(e.target.value)}
+        >
+          <option value=''>카테고리를 선택해주세요</option>
+          <option value='문화예술'>문화/예술</option>
+          <option value='푸드'>푸드</option>
+          <option value='스포츠'>스포츠</option>
+          <option value='투어'>투어</option>
+          <option value='관광'>관광</option>
+          <option value='웰빙'>웰빙</option>
+        </select>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(with-header)/myactivity/components/FormSection.tsx
+++ b/src/app/(with-header)/myactivity/components/FormSection.tsx
@@ -1,0 +1,27 @@
+import type React from 'react';
+
+interface FormSectionProps {
+  title: string;
+  children: React.ReactNode;
+  description?: string;
+}
+
+export function FormSection({
+  title,
+  children,
+  description,
+}: FormSectionProps) {
+  return (
+    <div className='space-y-6'>
+      <div>
+        <h2 className='border-b border-gray-200 pb-2 text-xl font-semibold text-gray-900'>
+          {title}
+        </h2>
+        {description && (
+          <p className='mt-2 text-sm text-gray-600'>{description}</p>
+        )}
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/src/app/(with-header)/myactivity/components/ImagePreview.tsx
+++ b/src/app/(with-header)/myactivity/components/ImagePreview.tsx
@@ -29,7 +29,7 @@ export function ImagePreview({
       <button
         type='button'
         onClick={onRemove}
-        className='absolute top-2 right-2 rounded-full bg-gray-600 p-1 text-white opacity-0 transition-colors group-hover:opacity-100 hover:bg-gray-700'
+        className='absolute top-2 right-2 rounded-full bg-gray-600 p-1 text-white transition-colors hover:bg-gray-700'
         aria-label='이미지 삭제'
       >
         <IconClose />

--- a/src/app/(with-header)/myactivity/components/ImagePreview.tsx
+++ b/src/app/(with-header)/myactivity/components/ImagePreview.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import IconClose from '@assets/svg/close';
+
+interface ImagePreviewProps {
+  image: File | string;
+  onRemove: () => void;
+  alt: string;
+  className?: string;
+}
+
+export function ImagePreview({
+  image,
+  onRemove,
+  alt,
+  className = '',
+}: ImagePreviewProps) {
+  const src = typeof image === 'string' ? image : URL.createObjectURL(image);
+
+  return (
+    <div className={`group relative ${className}`}>
+      <div className='aspect-square w-full overflow-hidden rounded-lg'>
+        <img
+          src={src || '/placeholder.svg'}
+          className='h-full w-full object-cover'
+          alt={alt}
+        />
+      </div>
+      <button
+        type='button'
+        onClick={onRemove}
+        className='absolute top-2 right-2 rounded-full bg-gray-600 p-1 text-white opacity-0 transition-colors group-hover:opacity-100 hover:bg-gray-700'
+        aria-label='이미지 삭제'
+      >
+        <IconClose />
+      </button>
+    </div>
+  );
+}

--- a/src/app/(with-header)/myactivity/components/ImageSection.tsx
+++ b/src/app/(with-header)/myactivity/components/ImageSection.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { MainImageSelect } from './MainImageSelect';
+import { SubImageSelect } from './SubImageSelect';
+
+interface ImagesSectionProps {
+  mainImage: string | File | null;
+  subImage: (string | File)[];
+  onMainImageSelect: (file: File) => void;
+  onMainImageRemove: () => void;
+  onSubImageAdd: (files: File[]) => void;
+  onSubImageRemove: (index: number) => void;
+}
+
+export function ImageSection({
+  mainImage,
+  subImage,
+  onMainImageSelect,
+  onMainImageRemove,
+  onSubImageAdd,
+  onSubImageRemove,
+}: ImagesSectionProps) {
+  return (
+    <div className='space-y-8'>
+      <MainImageSelect
+        mainImage={mainImage}
+        onImageSelect={onMainImageSelect}
+        onImageRemove={onMainImageRemove}
+      />
+
+      <SubImageSelect
+        subImage={subImage}
+        onImagesAdd={onSubImageAdd}
+        onImageRemove={onSubImageRemove}
+      />
+    </div>
+  );
+}

--- a/src/app/(with-header)/myactivity/components/ImageUpload.tsx
+++ b/src/app/(with-header)/myactivity/components/ImageUpload.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import type React from 'react';
+
+interface ImageUploadProps {
+  onImageSelect: (file: File) => void;
+  multiple?: boolean;
+  className?: string;
+  children?: React.ReactNode;
+}
+
+export function ImageUpload({
+  onImageSelect,
+  multiple = false,
+  className = '',
+  children,
+}: ImageUploadProps) {
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      onImageSelect(file);
+    }
+  };
+
+  return (
+    <label className={`group cursor-pointer ${className}`}>
+      <div className='flex aspect-square w-full flex-col items-center justify-center rounded-lg border-2 border-dashed border-gray-300 transition-colors hover:border-green-400 hover:bg-green-50'>
+        {children || (
+          <>
+            <h2 className='text-xl text-gray-600 group-hover:text-green-600'>
+              +
+            </h2>
+            <span className='text-center text-xs font-medium text-gray-600 group-hover:text-green-600'>
+              이미지
+              <br />
+              등록
+            </span>
+          </>
+        )}
+      </div>
+      <input
+        type='file'
+        accept='image/*'
+        multiple={multiple}
+        className='hidden'
+        onChange={handleFileChange}
+      />
+    </label>
+  );
+}

--- a/src/app/(with-header)/myactivity/components/InfoSection.tsx
+++ b/src/app/(with-header)/myactivity/components/InfoSection.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import Input from '@/components/Input';
+import AddressInput from './AddressInput';
+
+interface InfoSectionProps {
+  title?: string;
+  category?: string;
+  price?: number;
+  description?: string;
+  address?: string;
+  onTitleChange: (value: string) => void;
+  onCategoryChange: (value: string) => void;
+  onPriceChange: (value: string) => void;
+  onDescriptionChange: (value: string) => void;
+  onAddressChange: (value: string) => void;
+}
+
+export function InfoSection({
+  title = '',
+  category = '',
+  price = 0,
+  description = '',
+  address = '',
+  onTitleChange,
+  onCategoryChange,
+  onPriceChange,
+  onDescriptionChange,
+  onAddressChange,
+}: InfoSectionProps) {
+  return (
+    <section className='space-y-6'>
+      <div className='grid grid-cols-1 gap-6 sm:grid-cols-2'>
+        <div className='sm:col-span-2'>
+          <Input
+            label='제목'
+            id='title'
+            type='text'
+            placeholder='체험의 제목을 입력해주세요'
+            className='w-full'
+            value={title}
+            onChange={(e) => onTitleChange(e.target.value)}
+          />
+        </div>
+
+        <div>
+          <label
+            htmlFor='category'
+            className='mb-2 block text-sm font-medium text-gray-700'
+          >
+            카테고리 *
+          </label>
+          <select
+            id='category'
+            className='w-full rounded-md border bg-white px-20 py-15 placeholder-gray-600'
+            value={category}
+            onChange={(e) => onCategoryChange(e.target.value)}
+          >
+            <option value=''>카테고리를 선택해주세요</option>
+            <option value='outdoor'>문화/예술</option>
+            <option value='culture'>식음료</option>
+            <option value='food'>스포츠</option>
+            <option value='craft'>투어</option>
+            <option value='craft'>관광</option>
+            <option value='craft'>웰빙</option>
+          </select>
+        </div>
+
+        <div>
+          <div className='relative'>
+            <Input
+              label='가격'
+              type='number'
+              placeholder='0'
+              className='w-full appearance-none'
+              value={price}
+              onChange={(e) => onPriceChange(e.target.value)}
+            />
+            <span className='absolute top-1/2 right-4 -translate-y-1/2 transform text-gray-500'>
+              원
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div>
+        <Input
+          label='설명'
+          type='textarea'
+          placeholder='체험에 대한 자세한 설명을 입력해주세요'
+          className='w-full'
+          value={description}
+          onChange={(e) => onDescriptionChange(e.target.value)}
+        />
+      </div>
+
+      <div>
+        <AddressInput onAddressChange={onAddressChange} address={address} />
+      </div>
+    </section>
+  );
+}

--- a/src/app/(with-header)/myactivity/components/InfoSection.tsx
+++ b/src/app/(with-header)/myactivity/components/InfoSection.tsx
@@ -2,6 +2,7 @@
 
 import Input from '@/components/Input';
 import AddressInput from './AddressInput';
+import CategoryInput from './CategoryInput';
 
 interface InfoSectionProps {
   title?: string;
@@ -43,28 +44,10 @@ export function InfoSection({
           />
         </div>
 
-        <div>
-          <label
-            htmlFor='category'
-            className='mb-2 block text-sm font-medium text-gray-700'
-          >
-            카테고리 *
-          </label>
-          <select
-            id='category'
-            className='w-full rounded-md border bg-white px-20 py-15 placeholder-gray-600'
-            value={category}
-            onChange={(e) => onCategoryChange(e.target.value)}
-          >
-            <option value=''>카테고리를 선택해주세요</option>
-            <option value='outdoor'>문화/예술</option>
-            <option value='culture'>식음료</option>
-            <option value='food'>스포츠</option>
-            <option value='craft'>투어</option>
-            <option value='craft'>관광</option>
-            <option value='craft'>웰빙</option>
-          </select>
-        </div>
+        <CategoryInput
+          category={category}
+          onCategoryChange={onCategoryChange}
+        />
 
         <div>
           <div className='relative'>

--- a/src/app/(with-header)/myactivity/components/MainImageSelect.tsx
+++ b/src/app/(with-header)/myactivity/components/MainImageSelect.tsx
@@ -1,0 +1,58 @@
+'use client';
+import IconClose from '@assets/svg/close';
+import { ImageUpload } from './ImageUpload';
+
+interface MainImageSelectProps {
+  mainImage: File | string | null;
+  onImageSelect: (file: File) => void;
+  onImageRemove: () => void;
+}
+
+export function MainImageSelect({
+  mainImage,
+  onImageSelect,
+  onImageRemove,
+}: MainImageSelectProps) {
+  const previewUrl =
+    typeof mainImage === 'string'
+      ? mainImage
+      : mainImage
+        ? URL.createObjectURL(mainImage)
+        : '';
+
+  return (
+    <div>
+      <h3 className='mb-3 text-2xl font-bold text-black'>배너 이미지</h3>
+      <p className='mb-4 text-sm text-gray-600'>
+        체험을 대표하는 메인 이미지를 등록해주세요.
+      </p>
+
+      <div className='grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3'>
+        {!mainImage ? (
+          <ImageUpload
+            onImageSelect={onImageSelect}
+            className='sm:col-span-1'
+          />
+        ) : (
+          <div className='group relative sm:col-span-1'>
+            <div className='aspect-square w-full overflow-hidden rounded-lg'>
+              <img
+                src={previewUrl || '/placeholder.svg'}
+                className='h-full w-full object-cover'
+                alt='배너 이미지'
+              />
+            </div>
+            <button
+              type='button'
+              onClick={onImageRemove}
+              className='absolute top-2 right-2 rounded-full p-1 text-white opacity-0 transition-colors group-hover:opacity-100 hover:bg-gray-700'
+              aria-label='이미지 삭제'
+            >
+              <IconClose />
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(with-header)/myactivity/components/MainImageSelect.tsx
+++ b/src/app/(with-header)/myactivity/components/MainImageSelect.tsx
@@ -1,6 +1,8 @@
 'use client';
+
 import IconClose from '@assets/svg/close';
 import { ImageUpload } from './ImageUpload';
+import { ImagePreview } from './ImagePreview';
 
 interface MainImageSelectProps {
   mainImage: File | string | null;
@@ -13,13 +15,6 @@ export function MainImageSelect({
   onImageSelect,
   onImageRemove,
 }: MainImageSelectProps) {
-  const previewUrl =
-    typeof mainImage === 'string'
-      ? mainImage
-      : mainImage
-        ? URL.createObjectURL(mainImage)
-        : '';
-
   return (
     <div>
       <h3 className='mb-3 text-2xl font-bold text-black'>배너 이미지</h3>
@@ -27,32 +22,21 @@ export function MainImageSelect({
         체험을 대표하는 메인 이미지를 등록해주세요.
       </p>
 
-      <div className='grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3'>
-        {!mainImage ? (
-          <ImageUpload
-            onImageSelect={onImageSelect}
-            className='sm:col-span-1'
+      <div className='grid grid-cols-2 gap-6 sm:grid-cols-3 lg:grid-cols-4'>
+        <ImageUpload onImageSelect={onImageSelect} />
+
+        {mainImage && (
+          <ImagePreview
+            image={mainImage}
+            onRemove={onImageRemove}
+            alt='메인 이미지'
           />
-        ) : (
-          <div className='group relative sm:col-span-1'>
-            <div className='aspect-square w-full overflow-hidden rounded-lg'>
-              <img
-                src={previewUrl || '/placeholder.svg'}
-                className='h-full w-full object-cover'
-                alt='배너 이미지'
-              />
-            </div>
-            <button
-              type='button'
-              onClick={onImageRemove}
-              className='absolute top-2 right-2 rounded-full p-1 text-white opacity-0 transition-colors group-hover:opacity-100 hover:bg-gray-700'
-              aria-label='이미지 삭제'
-            >
-              <IconClose />
-            </button>
-          </div>
         )}
       </div>
+
+      <p className='text-md mt-3 text-gray-500'>
+        * 메인 이미지는 1장만 등록할 수 있습니다.
+      </p>
     </div>
   );
 }

--- a/src/app/(with-header)/myactivity/components/MainImageSelect.tsx
+++ b/src/app/(with-header)/myactivity/components/MainImageSelect.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import IconClose from '@assets/svg/close';
 import { ImageUpload } from './ImageUpload';
 import { ImagePreview } from './ImagePreview';
 

--- a/src/app/(with-header)/myactivity/components/ReservationForm.tsx
+++ b/src/app/(with-header)/myactivity/components/ReservationForm.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+import type React from 'react';
+import { InfoSection } from './InfoSection';
+import { ScheduleSelectForm } from './ScheduleSelectForm';
+import { ImageSection } from './ImageSection';
+
+interface DateSlot {
+  date: string;
+  startTime: string;
+  endTime: string;
+}
+const mockData = {
+  title: '함께 배우면 즐거운 스트릿댄스',
+  category: '투어',
+  description: '둠칫 둠칫 두둠칫',
+  address: '서울특별시 강남구 테헤란로 427',
+  price: 10000,
+  schedules: [
+    { date: '2023-12-01', startTime: '12:00', endTime: '13:00' },
+    { date: '2023-12-05', startTime: '12:00', endTime: '13:00' },
+    { date: '2023-12-05', startTime: '13:00', endTime: '14:00' },
+    { date: '2023-12-05', startTime: '14:00', endTime: '15:00' },
+  ],
+  bannerImageUrl: '/test/image1.png',
+  subImageUrls: [
+    '/test/image2.png',
+    '/test/image3.png',
+    '/test/image4.png',
+    '/test/image5.png',
+  ],
+};
+
+export default function ReservationForm() {
+  const [dates, setDates] = useState<DateSlot[]>([
+    { date: '', startTime: '', endTime: '' },
+  ]);
+  const [mainImage, setMainImage] = useState<File | string | null>(null);
+  const [subImage, setSubImage] = useState<(File | string)[]>([]);
+
+  const [title, setTitle] = useState('');
+  const [category, setCategory] = useState('');
+  const [price, setPrice] = useState(0);
+  const [description, setDescription] = useState('');
+  const [address, setAddress] = useState('');
+
+  useEffect(() => {
+    // mock데이터로 수정페이지용 테스트
+    setTimeout(() => {
+      setTitle(mockData.title);
+      setCategory(mockData.category);
+      setPrice(mockData.price);
+      setDescription(mockData.description);
+      setAddress(mockData.address);
+      setDates(mockData.schedules);
+      setMainImage(mockData.bannerImageUrl);
+      setSubImage(mockData.subImageUrls);
+    }, 500);
+  }, []);
+
+  const handleAddDate = () => {
+    setDates([...dates, { date: '', startTime: '', endTime: '' }]);
+  };
+
+  const handleRemoveDate = (index: number) => {
+    setDates(dates.filter((_, i) => i !== index));
+  };
+
+  const handleDateChange = (
+    index: number,
+    field: keyof DateSlot,
+    value: string,
+  ) => {
+    const updatedDates = dates.map((date, i) =>
+      i === index ? { ...date, [field]: value } : date,
+    );
+    setDates(updatedDates);
+  };
+
+  const handleMainImageSelect = (file: File) => {
+    setMainImage(file);
+  };
+
+  const handleMainImageRemove = () => {
+    setMainImage(null);
+  };
+
+  const handleSubImagesAdd = (newFiles: File[]) => {
+    const remainingSlots = 4 - subImage.length;
+    const filesToAdd = newFiles.slice(0, remainingSlots);
+    setSubImage([...subImage, ...filesToAdd]);
+  };
+
+  const handleSubImageRemove = (index: number) => {
+    setSubImage(subImage.filter((_, i) => i !== index));
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    console.log('title:', title);
+    console.log('category:', category);
+    console.log('price:', price);
+    console.log('description:', description);
+    console.log('address:', address);
+    console.log('dates:', dates);
+    console.log('mainImage:', mainImage);
+    console.log('subImage:', subImage);
+  };
+
+  return (
+    <div className='min-h-screen bg-gray-50 px-4 py-8 sm:px-6 lg:px-8'>
+      <div className='mx-auto max-w-1200 p-4 sm:px-20 lg:p-8'>
+        <div className='overflow-hidden rounded-lg bg-white shadow-lg'>
+          <div className='px-6 py-8 sm:px-8 sm:py-10'>
+            <div className='mb-8 flex justify-between'>
+              <h1 className='mb-2 text-3xl font-bold text-gray-900'>
+                내 체험 등록
+              </h1>
+            </div>
+
+            <form onSubmit={handleSubmit} className='space-y-8'>
+              <InfoSection
+                title={title}
+                category={category}
+                price={price}
+                description={description}
+                address={address}
+                onTitleChange={setTitle}
+                onCategoryChange={setCategory}
+                onPriceChange={(value) => setPrice(Number(value))}
+                onDescriptionChange={setDescription}
+                onAddressChange={setAddress}
+              />
+
+              <ScheduleSelectForm
+                dates={dates}
+                onAddDate={handleAddDate}
+                onRemoveDate={handleRemoveDate}
+                onDateChange={handleDateChange}
+              />
+
+              <ImageSection
+                mainImage={mainImage}
+                subImage={subImage}
+                onMainImageSelect={handleMainImageSelect}
+                onMainImageRemove={handleMainImageRemove}
+                onSubImageAdd={handleSubImagesAdd}
+                onSubImageRemove={handleSubImageRemove}
+              />
+
+              <div className='border-t border-gray-200 pt-6'>
+                <button
+                  type='submit'
+                  className='w-full rounded-lg bg-green-600 px-6 py-4 text-lg font-semibold text-white shadow-lg transition-all duration-200 hover:bg-green-700 hover:shadow-xl focus:ring-4 focus:ring-green-200'
+                >
+                  체험 등록하기
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(with-header)/myactivity/components/ReservationForm.tsx
+++ b/src/app/(with-header)/myactivity/components/ReservationForm.tsx
@@ -6,6 +6,7 @@ import type React from 'react';
 import { InfoSection } from './InfoSection';
 import { ScheduleSelectForm } from './ScheduleSelectForm';
 import { ImageSection } from './ImageSection';
+import Button from '@/components/Button';
 
 interface DateSlot {
   date: string;
@@ -113,55 +114,50 @@ export default function ReservationForm() {
   return (
     <div className='min-h-screen bg-gray-50 px-4 py-8 sm:px-6 lg:px-8'>
       <div className='mx-auto max-w-1200 p-4 sm:px-20 lg:p-8'>
-        <div className='overflow-hidden rounded-lg bg-white shadow-lg'>
-          <div className='px-6 py-8 sm:px-8 sm:py-10'>
-            <div className='mb-8 flex justify-between'>
-              <h1 className='mb-2 text-3xl font-bold text-gray-900'>
-                내 체험 등록
-              </h1>
+        <form onSubmit={handleSubmit} className='space-y-8'>
+          <div className='mb-8 flex items-center justify-between'>
+            <h1 className='mb-2 text-3xl font-bold text-gray-900'>
+              내 체험 등록
+            </h1>
+            <div className='border-t border-gray-200 pt-6'>
+              <Button
+                variant='primary'
+                type='submit'
+                className='w-full px-5 py-10'
+              >
+                체험 등록하기
+              </Button>
             </div>
-
-            <form onSubmit={handleSubmit} className='space-y-8'>
-              <InfoSection
-                title={title}
-                category={category}
-                price={price}
-                description={description}
-                address={address}
-                onTitleChange={setTitle}
-                onCategoryChange={setCategory}
-                onPriceChange={(value) => setPrice(Number(value))}
-                onDescriptionChange={setDescription}
-                onAddressChange={setAddress}
-              />
-
-              <ScheduleSelectForm
-                dates={dates}
-                onAddDate={handleAddDate}
-                onRemoveDate={handleRemoveDate}
-                onDateChange={handleDateChange}
-              />
-
-              <ImageSection
-                mainImage={mainImage}
-                subImage={subImage}
-                onMainImageSelect={handleMainImageSelect}
-                onMainImageRemove={handleMainImageRemove}
-                onSubImageAdd={handleSubImagesAdd}
-                onSubImageRemove={handleSubImageRemove}
-              />
-
-              <div className='border-t border-gray-200 pt-6'>
-                <button
-                  type='submit'
-                  className='w-full rounded-lg bg-green-600 px-6 py-4 text-lg font-semibold text-white shadow-lg transition-all duration-200 hover:bg-green-700 hover:shadow-xl focus:ring-4 focus:ring-green-200'
-                >
-                  체험 등록하기
-                </button>
-              </div>
-            </form>
           </div>
-        </div>
+          <InfoSection
+            title={title}
+            category={category}
+            price={price}
+            description={description}
+            address={address}
+            onTitleChange={setTitle}
+            onCategoryChange={setCategory}
+            onPriceChange={(value) => setPrice(Number(value))}
+            onDescriptionChange={setDescription}
+            onAddressChange={setAddress}
+          />
+
+          <ScheduleSelectForm
+            dates={dates}
+            onAddDate={handleAddDate}
+            onRemoveDate={handleRemoveDate}
+            onDateChange={handleDateChange}
+          />
+
+          <ImageSection
+            mainImage={mainImage}
+            subImage={subImage}
+            onMainImageSelect={handleMainImageSelect}
+            onMainImageRemove={handleMainImageRemove}
+            onSubImageAdd={handleSubImagesAdd}
+            onSubImageRemove={handleSubImageRemove}
+          />
+        </form>
       </div>
     </div>
   );

--- a/src/app/(with-header)/myactivity/components/ScheduleSelect.tsx
+++ b/src/app/(with-header)/myactivity/components/ScheduleSelect.tsx
@@ -19,7 +19,7 @@ interface ScheduleSelectProps {
 export function ScheduleSelect({
   index,
   isRemovable,
-  onAddDate,
+
   onRemove,
   onDateChange,
   onStartTimeChange,

--- a/src/app/(with-header)/myactivity/components/ScheduleSelect.tsx
+++ b/src/app/(with-header)/myactivity/components/ScheduleSelect.tsx
@@ -33,30 +33,30 @@ export function ScheduleSelect({
       <div className='grid grid-cols-1 items-center gap-10 sm:grid-cols-4'>
         <div className='sm:col-span-1'>
           <Input
+            className='w-full'
             label='날짜'
             type='date'
             value={date}
-            className='w-full'
             onChange={(e) => onDateChange(index, e.target.value)}
           />
         </div>
 
         <div className='sm:col-span-1'>
           <Input
+            className='w-full'
             label='시작시간'
             type='time'
             value={startTime}
-            className='w-full'
             onChange={(e) => onStartTimeChange(index, e.target.value)}
           />
         </div>
 
         <div className='sm:col-span-1'>
           <Input
+            className='w-full'
             label='종료시간'
             type='time'
             value={endTime}
-            className='w-full'
             onChange={(e) => onEndTimeChange(index, e.target.value)}
           />
         </div>

--- a/src/app/(with-header)/myactivity/components/ScheduleSelect.tsx
+++ b/src/app/(with-header)/myactivity/components/ScheduleSelect.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import Input from '@/components/Input';
+import IconClose from '@assets/svg/close';
+
+interface ScheduleSelectProps {
+  index: number;
+  isRemovable: boolean;
+  onAddDate: () => void;
+  onRemove: (index: number) => void;
+  onDateChange: (index: number, value: string) => void;
+  onStartTimeChange: (index: number, value: string) => void;
+  onEndTimeChange: (index: number, value: string) => void;
+  date: string;
+  startTime: string;
+  endTime: string;
+}
+
+export function ScheduleSelect({
+  index,
+  isRemovable,
+  onAddDate,
+  onRemove,
+  onDateChange,
+  onStartTimeChange,
+  onEndTimeChange,
+  date,
+  startTime,
+  endTime,
+}: ScheduleSelectProps) {
+  return (
+    <div className='rounded-lg bg-gray-50 p-4'>
+      <div className='grid grid-cols-1 items-center gap-10 sm:grid-cols-4'>
+        <div className='sm:col-span-1'>
+          <Input
+            label='날짜'
+            type='date'
+            value={date}
+            className='w-full'
+            onChange={(e) => onDateChange(index, e.target.value)}
+          />
+        </div>
+
+        <div className='sm:col-span-1'>
+          <Input
+            label='시작시간'
+            type='time'
+            value={startTime}
+            className='w-full'
+            onChange={(e) => onStartTimeChange(index, e.target.value)}
+          />
+        </div>
+
+        <div className='sm:col-span-1'>
+          <Input
+            label='종료시간'
+            type='time'
+            value={endTime}
+            className='w-full'
+            onChange={(e) => onEndTimeChange(index, e.target.value)}
+          />
+        </div>
+
+        <div className='flex sm:col-span-1'>
+          {isRemovable && (
+            <button
+              type='button'
+              onClick={() => onRemove(index)}
+              className='mt-6 rounded-full p-2 text-red-600 transition-colors hover:bg-red-50 hover:text-red-800'
+            >
+              <IconClose />
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(with-header)/myactivity/components/ScheduleSelectForm.tsx
+++ b/src/app/(with-header)/myactivity/components/ScheduleSelectForm.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { ScheduleSelect } from './ScheduleSelect';
+
+interface ScheduleType {
+  date: string;
+  startTime: string;
+  endTime: string;
+}
+
+interface ScheduleSelectFormProps {
+  dates: ScheduleType[];
+  onAddDate: () => void;
+  onRemoveDate: (index: number) => void;
+  onDateChange: (index: number, field: keyof ScheduleType, value: string) => void;
+}
+
+export function ScheduleSelectForm({
+  dates,
+  onAddDate,
+  onRemoveDate,
+  onDateChange,
+}: ScheduleSelectFormProps) {
+  return (
+    <div className='space-y-4'>
+      <div className='flex justify-between'>
+        <h3 className='mb-3 text-2xl font-bold text-black'>예약 가능한 시간</h3>
+        <button
+          type='button'
+          onClick={onAddDate}
+          className='mt-6 rounded-full p-2 text-red-600 transition-colors hover:bg-red-50 hover:text-red-800'
+        >
+          +
+        </button>
+      </div>
+
+      {dates.map((dateSlot, idx) => (
+        <div className='flex'>
+          <ScheduleSelect
+            key={idx}
+            index={idx}
+            isRemovable={dates.length > 1}
+            onAddDate={onAddDate}
+            onRemove={onRemoveDate}
+            onDateChange={(index, value) => onDateChange(index, 'date', value)}
+            onStartTimeChange={(index, value) =>
+              onDateChange(index, 'startTime', value)
+            }
+            onEndTimeChange={(index, value) =>
+              onDateChange(index, 'endTime', value)
+            }
+            date={dateSlot.date}
+            startTime={dateSlot.startTime}
+            endTime={dateSlot.endTime}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/app/(with-header)/myactivity/components/ScheduleSelectForm.tsx
+++ b/src/app/(with-header)/myactivity/components/ScheduleSelectForm.tsx
@@ -12,7 +12,11 @@ interface ScheduleSelectFormProps {
   dates: ScheduleType[];
   onAddDate: () => void;
   onRemoveDate: (index: number) => void;
-  onDateChange: (index: number, field: keyof ScheduleType, value: string) => void;
+  onDateChange: (
+    index: number,
+    field: keyof ScheduleType,
+    value: string,
+  ) => void;
 }
 
 export function ScheduleSelectForm({
@@ -23,14 +27,14 @@ export function ScheduleSelectForm({
 }: ScheduleSelectFormProps) {
   return (
     <div className='space-y-4'>
-      <div className='flex justify-between'>
+      <div className='flex items-center justify-between'>
         <h3 className='mb-3 text-2xl font-bold text-black'>예약 가능한 시간</h3>
         <button
           type='button'
           onClick={onAddDate}
-          className='mt-6 rounded-full p-2 text-red-600 transition-colors hover:bg-red-50 hover:text-red-800'
+          className='mt-6 bg-green-300 px-10 py-5 hover:bg-green-600'
         >
-          +
+          <p className='text-2xl font-bold text-white'>+</p>
         </button>
       </div>
 

--- a/src/app/(with-header)/myactivity/components/SubImageSelect.tsx
+++ b/src/app/(with-header)/myactivity/components/SubImageSelect.tsx
@@ -1,0 +1,48 @@
+import { ImagePreview } from './ImagePreview';
+import { ImageUpload } from './ImageUpload';
+
+interface SubImageSelectProps {
+  subImage: (string | File)[];
+  onImagesAdd: (files: File[]) => void;
+  onImageRemove: (index: number) => void;
+}
+
+export function SubImageSelect({
+  subImage,
+  onImagesAdd,
+  onImageRemove,
+}: SubImageSelectProps) {
+  const handleImageUpload = (file: File) => {
+    if (subImage.length < 4) {
+      onImagesAdd([file]);
+    }
+  };
+
+  return (
+    <div>
+      <h3 className='mb-3 text-2xl font-bold text-black'>소개 이미지</h3>
+      <p className='mb-4 text-sm text-gray-600'>
+        체험의 상세한 모습을 보여주는 이미지들을 등록해주세요.
+      </p>
+
+      <div className='grid grid-cols-2 gap-20 sm:grid-cols-3 lg:grid-cols-4'>
+        {subImage.map((img, idx) => (
+          <ImagePreview
+            key={idx}
+            image={img}
+            onRemove={() => onImageRemove(idx)}
+            alt={`소개 이미지 ${idx + 1}`}
+          />
+        ))}
+
+        {subImage.length < 4 && (
+          <ImageUpload onImageSelect={handleImageUpload} />
+        )}
+      </div>
+
+      <p className='text-md mt-3 text-gray-500'>
+        * 이미지는 최대 4장까지 등록 가능합니다.
+      </p>
+    </div>
+  );
+}

--- a/src/app/(with-header)/myactivity/components/SubImageSelect.tsx
+++ b/src/app/(with-header)/myactivity/components/SubImageSelect.tsx
@@ -26,6 +26,9 @@ export function SubImageSelect({
       </p>
 
       <div className='grid grid-cols-2 gap-20 sm:grid-cols-3 lg:grid-cols-4'>
+        {subImage.length < 4 && (
+          <ImageUpload onImageSelect={handleImageUpload} />
+        )}
         {subImage.map((img, idx) => (
           <ImagePreview
             key={idx}
@@ -34,10 +37,6 @@ export function SubImageSelect({
             alt={`소개 이미지 ${idx + 1}`}
           />
         ))}
-
-        {subImage.length < 4 && (
-          <ImageUpload onImageSelect={handleImageUpload} />
-        )}
       </div>
 
       <p className='text-md mt-3 text-gray-500'>

--- a/src/app/(with-header)/myactivity/page.tsx
+++ b/src/app/(with-header)/myactivity/page.tsx
@@ -1,0 +1,9 @@
+import ReservationForm from './components/ReservationForm';
+
+export default function Page() {
+  return (
+    <div>
+      <ReservationForm />
+    </div>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -67,6 +67,7 @@
 
   html {
     font-family: 'Pretendard-Regular', sans-serif;
+    scrollbar-gutter: stable;
   }
 }
 


### PR DESCRIPTION
## 📌 변경 사항 개요

- 체험 등록/수정 페이지 로직 및 레이아웃

## 📝 상세 내용

- 다음 주소api를 사용한 주소선택 가능
- ImagePreview,ImageUpload 컴포넌트를 통한 배너,소개이미지 업로드및 미리보기
- 체험 가능 시간대 선택 구현
- Mock데이터를 통한 수정시 데이터 불러오기 확인완료

## 🔗 관련 이슈

- #70 

## 🖼️ 스크린샷(선택사항)

<img width="2560" height="1882" alt="screencapture-localhost-3000-myactivity-2025-07-25-16_25_52" src="https://github.com/user-attachments/assets/119c3f31-2ff1-44da-83a0-085bcf49a027" />


## 💡 참고 사항

- 상세 UI수정은 api연결후 마무리할 예정입니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 체험/이벤트 등록을 위한 예약 폼과 관련 입력 UI(주소, 카테고리, 이미지 업로드 및 미리보기, 일정 선택 등) 추가
  * 주소 검색 기능(다음 우편번호 서비스 연동) 및 카테고리 선택 드롭다운 제공
  * 메인/서브 이미지 업로드 및 미리보기, 최대 4장 제한 기능 제공
  * 일정(날짜, 시작/종료 시간) 추가 및 삭제 기능 제공

* **스타일**
  * 스크롤바 등장 시 레이아웃 변화 방지를 위한 글로벌 스타일(scrollbar-gutter) 추가

* **기타**
  * 외부 라이브러리 react-daum-postcode 의존성 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->