### PR TITLE
Feat/84 헤더 마이페이지, 로그아웃 드롭다운 추가 및 로그인 성공 UI 적용

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,13 +3,11 @@ import type { NextConfig } from 'next';
 const nextConfig: NextConfig = {
   // Docker 배포를 위한 standalone 모드 활성화
   // 해당 설정은 프로덕션 빌드 시 필요한 파일만 .next/standalone 폴더에 복사됨.
-  images: {
-    domains: ['sprint-fe-project.s3.ap-northeast-2.amazonaws.com'],
-  },
   output: 'standalone',
 
   // 외부 이미지 도메인 허용
   images: {
+    domains: ['sprint-fe-project.s3.ap-northeast-2.amazonaws.com'],
     remotePatterns: [
       {
         protocol: 'https',

--- a/src/app/api/experiences/getExperiences.ts
+++ b/src/app/api/experiences/getExperiences.ts
@@ -14,8 +14,8 @@ interface ExperienceResponse {
   cursorId: number;
 }
 
-const teamId = process.env.NEXT_PUBLIC_TEAM_ID;
-const url = `/${teamId}/activities`;
+const baseUrl = process.env.NEXT_PUBLIC_API_SERVER_URL;
+const url = `${baseUrl}/activities`;
 const validSorts = ['price_asc', 'price_desc'];
 
 export const getExperiences = async ({ page, category, sort, keyword }: Params) => {

--- a/src/app/api/experiences/getPopularExperiences.ts
+++ b/src/app/api/experiences/getPopularExperiences.ts
@@ -7,8 +7,8 @@ interface ResponseData {
   activities: Experience[];
 }
 
-const teamId = process.env.NEXT_PUBLIC_TEAM_ID;
-const url = `/${teamId}/activities`;
+const baseUrl = process.env.NEXT_PUBLIC_API_SERVER_URL;
+const url = `${baseUrl}/activities`;
 
 export const getPopularExperiences = async (): Promise<ResponseData> => {
   const res = await instance.get<ResponseData>(url, {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,13 +1,11 @@
 'use client';
 
 import Link from 'next/link';
-import Image from 'next/image';
 import IconLogo from '@assets/svg/logo';
 import IconBell from '@assets/svg/bell';
 import useUserStore from '@/stores/authStore';
-import { useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import ProfileDefaultIcon from '@assets/svg/profile-default';
+import ProfileDropdown from '@/components/ProfileDropdown';
 
 export default function Header() {
   const router = useRouter();
@@ -15,24 +13,7 @@ export default function Header() {
   const setUser = useUserStore((state) => state.setUser);
   const isLoggedIn = !!user;
 
-  const [isOpen, setIsOpen] = useState(false);
-  const dropdownRef = useRef<HTMLDivElement>(null);
-
-  // 바깥 클릭 시 드롭다운 닫기
-  useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
-      if (
-        dropdownRef.current &&
-        !dropdownRef.current.contains(e.target as Node)
-      ) {
-        setIsOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, []);
-
-  // 로그아웃 처리 후 홈 이동
+  // 로그아웃 처리
   const handleLogout = () => {
     setUser(null);
     router.push('/');
@@ -53,51 +34,20 @@ export default function Header() {
         <div className='text-md relative flex items-center gap-24 text-black'>
           {isLoggedIn ? (
             <>
+              {/* 알림 아이콘 */}
               <button aria-label='알림' className='hover:text-primary'>
                 <IconBell />
               </button>
 
+              {/* 구분선 */}
               <div className='mx-12 h-22 w-px bg-gray-300' />
 
-              {/* 프로필 + 드롭다운 */}
-              <div
-                className='flex items-center gap-8 cursor-pointer'
-                onClick={() => setIsOpen((prev) => !prev)}
-                ref={dropdownRef}
-              >
-                {user.profileImageUrl ? (
-                  <Image
-                    src={user.profileImageUrl}
-                    alt='프로필 이미지'
-                    width={32}
-                    height={32}
-                    className='rounded-full border border-gray-300'
-                  />
-                ) : (
-                  <div className='size-32 rounded-full border border-gray-300 overflow-hidden'>
-                    <ProfileDefaultIcon size={32} />
-                  </div>
-                )}
-                <span>{user.nickname || '사용자'}</span>
-
-                {/* 드롭다운 메뉴 */}
-                {isOpen && (
-                  <div className='absolute top-50 right-0 z-50 mt-20 w-120 rounded-md border border-gray-200 bg-white shadow-md'>
-                    <Link
-                      href='/mypage'
-                      className='block w-full px-16 py-12 text-left hover:bg-gray-50 cursor-pointer'
-                    >
-                      마이페이지
-                    </Link>
-                    <button
-                      onClick={handleLogout}
-                      className='w-full px-16 py-12 text-left hover:bg-gray-50 cursor-pointer'
-                    >
-                      로그아웃
-                    </button>
-                  </div>
-                )}
-              </div>
+              {/* 프로필 드롭다운 */}
+              <ProfileDropdown
+                nickname={user.nickname}
+                profileImageUrl={user.profileImageUrl}
+                onLogout={handleLogout}
+              />
             </>
           ) : (
             <>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,18 +2,44 @@
 
 import Link from 'next/link';
 import Image from 'next/image';
-import { useState } from 'react';
 import IconLogo from '@assets/svg/logo';
 import IconBell from '@assets/svg/bell';
+import useUserStore from '@/stores/authStore';
+import { useEffect, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import ProfileDefaultIcon from '@assets/svg/profile-default';
 
 export default function Header() {
-  // 실제로는 로그인 여부를 전역 상태나 context로 받아와야 함
-  // test하려면 로그인 상태를 true로 변경
-  // 빌드 에러로 인해 setIsLoggedIn 변수 앞에 _를 붙여 의도적으로 사용하지 않음을 표시
-  const [isLoggedIn, _setIsLoggedIn] = useState(false);
+  const router = useRouter();
+  const user = useUserStore((state) => state.user);
+  const setUser = useUserStore((state) => state.setUser);
+  const isLoggedIn = !!user;
+
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  // 바깥 클릭 시 드롭다운 닫기
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(e.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  // 로그아웃 처리 후 홈 이동
+  const handleLogout = () => {
+    setUser(null);
+    router.push('/');
+  };
 
   return (
-    <header className='fixed z-10 w-full border-b border-gray-300 bg-white'>
+    <header className='fixed z-100 w-full border-b border-gray-300 bg-white'>
       <div className='mx-auto flex min-h-70 max-w-1200 items-center justify-between px-20 py-20'>
         {/* 로고 */}
         <Link
@@ -24,27 +50,53 @@ export default function Header() {
         </Link>
 
         {/* 우측 메뉴 */}
-        <div className='text-md flex items-center gap-24 text-black'>
+        <div className='text-md relative flex items-center gap-24 text-black'>
           {isLoggedIn ? (
             <>
-              {/* 알림 아이콘 */}
               <button aria-label='알림' className='hover:text-primary'>
                 <IconBell />
               </button>
 
-              {/* 세로 구분선 */}
               <div className='mx-12 h-22 w-px bg-gray-300' />
 
-              {/* 유저 프로필 */}
-              <div className='flex items-center gap-2'>
-                <Image
-                  src='/img/sample-user.png' // 사용자 프로필 이미지
-                  alt='프로필 이미지'
-                  width={32}
-                  height={32}
-                  className='rounded-full border border-gray-300'
-                />
-                <span>김보경</span>
+              {/* 프로필 + 드롭다운 */}
+              <div
+                className='flex items-center gap-8 cursor-pointer'
+                onClick={() => setIsOpen((prev) => !prev)}
+                ref={dropdownRef}
+              >
+                {user.profileImageUrl ? (
+                  <Image
+                    src={user.profileImageUrl}
+                    alt='프로필 이미지'
+                    width={32}
+                    height={32}
+                    className='rounded-full border border-gray-300'
+                  />
+                ) : (
+                  <div className='size-32 rounded-full border border-gray-300 overflow-hidden'>
+                    <ProfileDefaultIcon size={32} />
+                  </div>
+                )}
+                <span>{user.nickname || '사용자'}</span>
+
+                {/* 드롭다운 메뉴 */}
+                {isOpen && (
+                  <div className='absolute top-50 right-0 z-50 mt-20 w-120 rounded-md border border-gray-200 bg-white shadow-md'>
+                    <Link
+                      href='/mypage'
+                      className='block w-full px-16 py-12 text-left hover:bg-gray-50 cursor-pointer'
+                    >
+                      마이페이지
+                    </Link>
+                    <button
+                      onClick={handleLogout}
+                      className='w-full px-16 py-12 text-left hover:bg-gray-50 cursor-pointer'
+                    >
+                      로그아웃
+                    </button>
+                  </div>
+                )}
               </div>
             </>
           ) : (

--- a/src/components/ProfileDropdown.tsx
+++ b/src/components/ProfileDropdown.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import { useEffect, useRef, useState } from 'react';
+import { usePathname } from 'next/navigation';
+import ProfileDefaultIcon from '@assets/svg/profile-default';
+
+import { ProfileDropdownProps } from '@/types/profileDropdownTypes';
+
+export default function ProfileDropdown({ nickname, profileImageUrl, onLogout }: ProfileDropdownProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const pathname = usePathname();
+
+  // 외부 클릭 시 드롭다운 닫기
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  // 경로 변경 시 드롭다운 닫기
+  useEffect(() => {
+    setIsOpen(false);
+  }, [pathname]);
+
+  return (
+    <div className='relative' ref={dropdownRef}>
+      {/* 프로필 영역 (드롭다운 토글) */}
+      <div
+        className='flex items-center gap-8 cursor-pointer'
+        onClick={() => setIsOpen((prev) => !prev)}
+      >
+        {profileImageUrl ? (
+          <Image
+            src={profileImageUrl}
+            alt='프로필 이미지'
+            width={32}
+            height={32}
+            className='rounded-full border border-gray-300'
+          />
+        ) : (
+          <div className='size-32 rounded-full border border-gray-300 overflow-hidden'>
+            <ProfileDefaultIcon size={32} />
+          </div>
+        )}
+        <span>{nickname || '사용자'}</span>
+      </div>
+
+      {/* 드롭다운 메뉴 */}
+      {isOpen && (
+        <div
+          className='absolute top-50 right-0 z-50 mt-12 w-140 rounded-md border border-gray-200 bg-white shadow-md'
+          onClick={(e) => e.stopPropagation()}
+        >
+          <Link
+            href='/mypage'
+            className='block w-full px-16 py-12 text-left hover:bg-gray-50'
+          >
+            마이페이지
+          </Link>
+          <button
+            onClick={onLogout}
+            className='w-full px-16 py-12 text-left hover:bg-gray-50'
+          >
+            로그아웃
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/types/profileDropdownTypes.ts
+++ b/src/types/profileDropdownTypes.ts
@@ -1,0 +1,5 @@
+export interface ProfileDropdownProps {
+  nickname: string;
+  profileImageUrl: string | null;
+  onLogout: () => void;
+}


### PR DESCRIPTION
## 📌 변경 사항 개요

<!-- 이 PR에서 수행한 변경 사항에 대한 간략한 설명 -->
- Header 컴포넌트 내 드롭다운 기능을 분리하고 UI/UX 개선
- 사용자 정보에 따른 드롭다운 렌더링 및 반응형 처리

## 📝 상세 내용

<!-- 구현 내용에 대한 자세한 설명 -->
- [x] ProfileDropdown.tsx 컴포넌트로 드롭다운 로직 분리
- [x] 유저 프로필 이미지 없을 경우 기본 SVG 아이콘으로 fallback
- [x] 드롭다운 내부 메뉴 구성
- [x] profileDropdownTypes.ts 파일 생성 및 타입 분리 적용

## 🔗 관련 이슈

<!-- 관련된 이슈 번호 (예: Resolves: #123) -->
- #84 

## 🖼️ 스크린샷(선택사항)

<!-- UI 변경이 있는 경우 변경 전/후 스크린샷 -->


https://github.com/user-attachments/assets/c4fc69c5-b29e-49e3-a29d-6c5d53a59565


## 💡 참고 사항
- 프로필 이미지 변경 시 실시간 반영이 안 되는 문제 추후 해결 예정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 사용자 프로필 드롭다운 메뉴가 추가되어, 프로필 이미지와 닉네임 표시 및 로그아웃 기능을 제공합니다.

* **개선 사항**
  * 헤더에서 로그인 상태 관리가 전역 상태로 변경되어, 사용자 정보가 동적으로 반영됩니다.
  * 헤더의 프로필 영역이 ProfileDropdown 컴포넌트로 대체되어 UI가 개선되었습니다.
  * Next.js 이미지 도메인 설정이 통합되어 관리가 간소화되었습니다.

* **기타**
  * API 호출 시 서버 URL 구성이 변경되어, 환경 변수 기반의 절대 경로를 사용합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->