### PR TITLE
Feat/86 체험 수정 페이지 api 적용

### DIFF
--- a/src/app/(with-header)/activities/[id]/components/ActivityDetailForm.tsx
+++ b/src/app/(with-header)/activities/[id]/components/ActivityDetailForm.tsx
@@ -71,6 +71,8 @@ export default function ActivityDetailForm() {
     enabled: !!id && !!year && !!month,
   });
 
+  
+
   if (isLoading || !activityData) {
     return <div>로딩 중...</div>;
   }

--- a/src/app/(with-header)/activities/[id]/components/Title.tsx
+++ b/src/app/(with-header)/activities/[id]/components/Title.tsx
@@ -6,6 +6,9 @@ import ActivityDropdown from '@/components/ActivityDropdown';
 import Menu from '@/components/ActivityDropdown/menu';
 import Item from '@/components/ActivityDropdown/Item';
 import Trigger from '@/components/ActivityDropdown/trigger';
+import { useParams } from 'next/navigation';
+import { useRouter } from 'next/navigation';
+import { useQueryClient } from '@tanstack/react-query';
 
 export default function Title({
   title,
@@ -15,6 +18,15 @@ export default function Title({
   address,
   isOwner,
 }: ActivityDetail) {
+  const { id } = useParams();
+  const router = useRouter();
+  const queryClient = useQueryClient();
+
+  const handleEdit = () => {
+    queryClient.invalidateQueries({ queryKey: ['edit-activity', id] });
+    router.push(`/myactivity/${id}`);
+  };
+
   return (
     <div className='mb-6 flex items-start justify-between'>
       <div className='flex flex-col gap-8'>
@@ -39,7 +51,7 @@ export default function Title({
             <IconDropdown />
           </Trigger>
           <Menu>
-            <Item onClick={() => alert('수정')}>수정하기</Item>
+            <Item onClick={handleEdit}>수정하기</Item>
             <Item onClick={() => alert('삭제')}>삭제하기</Item>
           </Menu>
         </ActivityDropdown>

--- a/src/app/(with-header)/myactivity/[id]/components/EditActivityForm.tsx
+++ b/src/app/(with-header)/myactivity/[id]/components/EditActivityForm.tsx
@@ -1,203 +1,37 @@
 'use client';
 
-import { useState, useEffect } from 'react';
-import { useParams } from 'next/navigation';
-import { useQuery } from '@tanstack/react-query';
 import Button from '@/components/Button';
 import { InfoSection } from '../../components/InfoSection';
 import { ScheduleSelectForm } from '../../components/ScheduleSelectForm';
 import { ImageSection } from '../../components/ImageSection';
-import { uploadImage } from '../../utils/uploadImage';
-import { privateInstance } from '@/apis/privateInstance';
-import { ActivityDetailEdit, Schedule } from '@/types/activityDetailType';
-import { AxiosError } from 'axios';
-import { useRouter } from 'next/navigation';
-import { useQueryClient } from '@tanstack/react-query';
-
-interface SubImageType {
-  id?: number;
-  url: string | File;
-}
+import { useEditActivityForm } from '../hooks/useEditActivityForm';
 
 export default function EditActivityForm() {
-  const { id } = useParams() as { id: string };
-
-  const router = useRouter();
-  const queryClient = useQueryClient();
-
-
-  const [title, setTitle] = useState('');
-  const [category, setCategory] = useState('');
-  const [price, setPrice] = useState(0);
-  const [description, setDescription] = useState('');
-  const [address, setAddress] = useState('');
-
-  const [mainImage, setMainImage] = useState<File | string | null>(null);
-
-
-  const [originalSubImages, setOriginalSubImages] = useState<SubImageType[]>(
-    [],
-  );
-  const [subImages, setSubImages] = useState<SubImageType[]>([]);
-
-  const [originalSchedules, setOriginalSchedules] = useState<Schedule[]>([]);
-  const [dates, setDates] = useState<Schedule[]>([]);
-
- 
-  const { data, isLoading, error } = useQuery<ActivityDetailEdit, Error>({
-    queryKey: ['edit-activity', id],
-    queryFn: async () => {
-      const res = await privateInstance.get(`/activities/${id}`);
-      return res.data;
-    },
-    enabled: !!id,
-  });
-
-
-  useEffect(() => {
-    if (data) {
-      setTitle(data.title);
-      setCategory(data.category);
-      setPrice(data.price);
-      setDescription(data.description);
-      setAddress(data.address);
-      setMainImage(data.bannerImageUrl);
-
-      const mappedSubImages: SubImageType[] =
-        data.subImages?.map((img) => ({
-          id: img.id,
-          url: img.imageUrl,
-        })) ?? [];
-
-      setOriginalSubImages(mappedSubImages);
-      setSubImages(mappedSubImages);
-
-      setOriginalSchedules(data.schedules ?? []);
-      setDates(data.schedules ?? []);
-    }
-  }, [data]);
-
-
-  const handleSubImageRemove = (index: number) => {
-    setSubImages((prev) => prev.filter((_, i) => i !== index));
-  };
-
-
-  const handleSubImagesAdd = (newFiles: File[]) => {
-    const remainingSlots = 4 - subImages.length;
-    const filesToAdd = newFiles.slice(0, remainingSlots);
-    const newSubImages = filesToAdd.map((file) => ({ url: file }));
-    setSubImages((prev) => [...prev, ...newSubImages]);
-  };
-
- 
-  const handleAddDate = () => {
-    setDates([...dates, { date: '', startTime: '', endTime: '' }]);
-  };
-
- 
-  const handleRemoveDate = (index: number) => {
-    setDates(dates.filter((_, i) => i !== index));
-  };
-
-  const handleDateChange = (
-    index: number,
-    field: keyof Schedule,
-    value: string,
-  ) => {
-    setDates((prev) =>
-      prev.map((item, i) => (i === index ? { ...item, [field]: value } : item)),
-    );
-  };
-
-
-  const handleMainImageSelect = (file: File) => {
-    setMainImage(file);
-  };
-
- 
-  const handleMainImageRemove = () => {
-    setMainImage(null);
-  };
-
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-
-    try {
-    
-      let bannerImageUrl = '';
-      if (typeof mainImage === 'string') {
-        bannerImageUrl = mainImage;
-      } else if (mainImage instanceof File) {
-        bannerImageUrl = await uploadImage(mainImage);
-      }
-
-      // 삭제될 서브 이미지 id
-      const subImageIdsToRemove = originalSubImages
-        .filter((orig) => !subImages.some((img) => img.id === orig.id))
-        .map((img) => img.id)
-        .filter((id): id is number => id !== undefined);
-
- 
-      const subImageUrlsToAdd: string[] = [];
-
-      for (const img of subImages) {
-        if (!img.id) {
-          if (img.url instanceof File) {
-            const uploadedUrl = await uploadImage(img.url);
-            subImageUrlsToAdd.push(uploadedUrl);
-          } else if (typeof img.url === 'string') {
-            subImageUrlsToAdd.push(img.url);
-          }
-        }
-      }
-
-      //id가 없으면 새로 생긴 일정
-      const newSchedules = dates.filter((d) => !d.id);
-
-      // 삭제할 일정
-      const scheduleIdsToRemove = originalSchedules
-        .filter((orig) => !dates.some((d) => d.id === orig.id))
-        .map((d) => d.id)
-        .filter((id): id is number => id !== undefined);
-
-      // 페이로드 구성
-      const payload = {
-        title,
-        category,
-        description,
-        address,
-        price,
-        bannerImageUrl,
-        subImageIdsToRemove,
-        subImageUrlsToAdd,
-        schedulesToAdd: newSchedules,
-        scheduleIdsToRemove,
-      };
-
-      await privateInstance.patch(`/editActivity/${id}`, payload);
-
-      alert('수정이 완료되었습니다.');
-      queryClient.invalidateQueries({ queryKey: ['activity', id] });
-      router.push(`/activities/${id}`);
-    } catch (err) {
-      const error = err as AxiosError;
-
-      const responseData = error.response?.data as
-        | { error?: string; message?: string }
-        | undefined;
-
-      console.error('전체 에러:', error);
-
-      alert(
-        responseData?.error ||
-          responseData?.message ||
-          error.message ||
-          '예약에 실패했습니다.',
-      );
-    }
-  };
+  const {
+    title,
+    category,
+    price,
+    description,
+    address,
+    mainImage,
+    subImages,
+    dates,
+    isLoading,
+    error,
+    setTitle,
+    setCategory,
+    setPrice,
+    setDescription,
+    setAddress,
+    handleSubImageRemove,
+    handleSubImagesAdd,
+    handleAddDate,
+    handleRemoveDate,
+    handleDateChange,
+    handleMainImageSelect,
+    handleMainImageRemove,
+    handleSubmit,
+  } = useEditActivityForm();
 
   if (isLoading) return <div>로딩 중...</div>;
   if (error) return <div>오류가 발생했습니다: {error.message}</div>;
@@ -221,7 +55,7 @@ export default function EditActivityForm() {
             address={address}
             onTitleChange={setTitle}
             onCategoryChange={setCategory}
-            onPriceChange={(v) => setPrice(Number(v))}
+            onPriceChange={(price) => setPrice(Number(price))}
             onDescriptionChange={setDescription}
             onAddressChange={setAddress}
           />
@@ -235,7 +69,7 @@ export default function EditActivityForm() {
 
           <ImageSection
             mainImage={mainImage}
-            subImage={subImages.map((img) => img.url)}
+            subImage={subImages.map((img: any) => img.url)}
             onMainImageSelect={handleMainImageSelect}
             onMainImageRemove={handleMainImageRemove}
             onSubImageAdd={handleSubImagesAdd}

--- a/src/app/(with-header)/myactivity/[id]/components/EditActivityForm.tsx
+++ b/src/app/(with-header)/myactivity/[id]/components/EditActivityForm.tsx
@@ -6,6 +6,11 @@ import { ScheduleSelectForm } from '../../components/ScheduleSelectForm';
 import { ImageSection } from '../../components/ImageSection';
 import { useEditActivityForm } from '../hooks/useEditActivityForm';
 
+interface SubImageType {
+  id?: number;
+  url: string | File;
+}
+
 export default function EditActivityForm() {
   const {
     title,
@@ -69,7 +74,7 @@ export default function EditActivityForm() {
 
           <ImageSection
             mainImage={mainImage}
-            subImage={subImages.map((img: any) => img.url)}
+            subImage={subImages.map((img: SubImageType) => img.url)}
             onMainImageSelect={handleMainImageSelect}
             onMainImageRemove={handleMainImageRemove}
             onSubImageAdd={handleSubImagesAdd}

--- a/src/app/(with-header)/myactivity/[id]/components/EditActivityForm.tsx
+++ b/src/app/(with-header)/myactivity/[id]/components/EditActivityForm.tsx
@@ -1,0 +1,248 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useParams } from 'next/navigation';
+import { useQuery } from '@tanstack/react-query';
+import Button from '@/components/Button';
+import { InfoSection } from '../../components/InfoSection';
+import { ScheduleSelectForm } from '../../components/ScheduleSelectForm';
+import { ImageSection } from '../../components/ImageSection';
+import { uploadImage } from '../../utils/uploadImage';
+import { privateInstance } from '@/apis/privateInstance';
+import { ActivityDetailEdit, Schedule } from '@/types/activityDetailType';
+import { AxiosError } from 'axios';
+import { useRouter } from 'next/navigation';
+import { useQueryClient } from '@tanstack/react-query';
+
+interface SubImageType {
+  id?: number;
+  url: string | File;
+}
+
+export default function EditActivityForm() {
+  const { id } = useParams() as { id: string };
+
+  const router = useRouter();
+  const queryClient = useQueryClient();
+
+
+  const [title, setTitle] = useState('');
+  const [category, setCategory] = useState('');
+  const [price, setPrice] = useState(0);
+  const [description, setDescription] = useState('');
+  const [address, setAddress] = useState('');
+
+  const [mainImage, setMainImage] = useState<File | string | null>(null);
+
+
+  const [originalSubImages, setOriginalSubImages] = useState<SubImageType[]>(
+    [],
+  );
+  const [subImages, setSubImages] = useState<SubImageType[]>([]);
+
+  const [originalSchedules, setOriginalSchedules] = useState<Schedule[]>([]);
+  const [dates, setDates] = useState<Schedule[]>([]);
+
+ 
+  const { data, isLoading, error } = useQuery<ActivityDetailEdit, Error>({
+    queryKey: ['edit-activity', id],
+    queryFn: async () => {
+      const res = await privateInstance.get(`/activities/${id}`);
+      return res.data;
+    },
+    enabled: !!id,
+  });
+
+
+  useEffect(() => {
+    if (data) {
+      setTitle(data.title);
+      setCategory(data.category);
+      setPrice(data.price);
+      setDescription(data.description);
+      setAddress(data.address);
+      setMainImage(data.bannerImageUrl);
+
+      const mappedSubImages: SubImageType[] =
+        data.subImages?.map((img) => ({
+          id: img.id,
+          url: img.imageUrl,
+        })) ?? [];
+
+      setOriginalSubImages(mappedSubImages);
+      setSubImages(mappedSubImages);
+
+      setOriginalSchedules(data.schedules ?? []);
+      setDates(data.schedules ?? []);
+    }
+  }, [data]);
+
+
+  const handleSubImageRemove = (index: number) => {
+    setSubImages((prev) => prev.filter((_, i) => i !== index));
+  };
+
+
+  const handleSubImagesAdd = (newFiles: File[]) => {
+    const remainingSlots = 4 - subImages.length;
+    const filesToAdd = newFiles.slice(0, remainingSlots);
+    const newSubImages = filesToAdd.map((file) => ({ url: file }));
+    setSubImages((prev) => [...prev, ...newSubImages]);
+  };
+
+ 
+  const handleAddDate = () => {
+    setDates([...dates, { date: '', startTime: '', endTime: '' }]);
+  };
+
+ 
+  const handleRemoveDate = (index: number) => {
+    setDates(dates.filter((_, i) => i !== index));
+  };
+
+  const handleDateChange = (
+    index: number,
+    field: keyof Schedule,
+    value: string,
+  ) => {
+    setDates((prev) =>
+      prev.map((item, i) => (i === index ? { ...item, [field]: value } : item)),
+    );
+  };
+
+
+  const handleMainImageSelect = (file: File) => {
+    setMainImage(file);
+  };
+
+ 
+  const handleMainImageRemove = () => {
+    setMainImage(null);
+  };
+
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    try {
+    
+      let bannerImageUrl = '';
+      if (typeof mainImage === 'string') {
+        bannerImageUrl = mainImage;
+      } else if (mainImage instanceof File) {
+        bannerImageUrl = await uploadImage(mainImage);
+      }
+
+      // 삭제될 서브 이미지 id
+      const subImageIdsToRemove = originalSubImages
+        .filter((orig) => !subImages.some((img) => img.id === orig.id))
+        .map((img) => img.id)
+        .filter((id): id is number => id !== undefined);
+
+ 
+      const subImageUrlsToAdd: string[] = [];
+
+      for (const img of subImages) {
+        if (!img.id) {
+          if (img.url instanceof File) {
+            const uploadedUrl = await uploadImage(img.url);
+            subImageUrlsToAdd.push(uploadedUrl);
+          } else if (typeof img.url === 'string') {
+            subImageUrlsToAdd.push(img.url);
+          }
+        }
+      }
+
+      //id가 없으면 새로 생긴 일정
+      const newSchedules = dates.filter((d) => !d.id);
+
+      // 삭제할 일정
+      const scheduleIdsToRemove = originalSchedules
+        .filter((orig) => !dates.some((d) => d.id === orig.id))
+        .map((d) => d.id)
+        .filter((id): id is number => id !== undefined);
+
+      // 페이로드 구성
+      const payload = {
+        title,
+        category,
+        description,
+        address,
+        price,
+        bannerImageUrl,
+        subImageIdsToRemove,
+        subImageUrlsToAdd,
+        schedulesToAdd: newSchedules,
+        scheduleIdsToRemove,
+      };
+
+      await privateInstance.patch(`/editActivity/${id}`, payload);
+
+      alert('수정이 완료되었습니다.');
+      queryClient.invalidateQueries({ queryKey: ['activity', id] });
+      router.push(`/activities/${id}`);
+    } catch (err) {
+      const error = err as AxiosError;
+
+      const responseData = error.response?.data as
+        | { error?: string; message?: string }
+        | undefined;
+
+      console.error('전체 에러:', error);
+
+      alert(
+        responseData?.error ||
+          responseData?.message ||
+          error.message ||
+          '예약에 실패했습니다.',
+      );
+    }
+  };
+
+  if (isLoading) return <div>로딩 중...</div>;
+  if (error) return <div>오류가 발생했습니다: {error.message}</div>;
+
+  return (
+    <div className='min-h-screen bg-gray-50 px-4 py-8 sm:px-6 lg:px-8'>
+      <div className='mx-auto max-w-1200 p-4 sm:px-20 lg:p-8'>
+        <form onSubmit={handleSubmit} className='space-y-8'>
+          <div className='mb-8 flex items-center justify-between'>
+            <h1 className='text-3xl font-bold'>체험 수정</h1>
+            <Button type='submit' variant='primary' className='px-6 py-3'>
+              수정 완료
+            </Button>
+          </div>
+
+          <InfoSection
+            title={title}
+            category={category}
+            price={price}
+            description={description}
+            address={address}
+            onTitleChange={setTitle}
+            onCategoryChange={setCategory}
+            onPriceChange={(v) => setPrice(Number(v))}
+            onDescriptionChange={setDescription}
+            onAddressChange={setAddress}
+          />
+
+          <ScheduleSelectForm
+            dates={dates}
+            onAddDate={handleAddDate}
+            onRemoveDate={handleRemoveDate}
+            onDateChange={handleDateChange}
+          />
+
+          <ImageSection
+            mainImage={mainImage}
+            subImage={subImages.map((img) => img.url)}
+            onMainImageSelect={handleMainImageSelect}
+            onMainImageRemove={handleMainImageRemove}
+            onSubImageAdd={handleSubImagesAdd}
+            onSubImageRemove={handleSubImageRemove}
+          />
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(with-header)/myactivity/[id]/hooks/useEditActivityForm.ts
+++ b/src/app/(with-header)/myactivity/[id]/hooks/useEditActivityForm.ts
@@ -1,0 +1,198 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { privateInstance } from '@/apis/privateInstance';
+import { uploadImage } from '../../utils/uploadImage';
+import { ActivityDetailEdit, Schedule } from '@/types/activityDetailType';
+import { AxiosError } from 'axios';
+
+interface SubImageType {
+  id?: number;
+  url: string | File;
+}
+
+export const useEditActivityForm = () => {
+  const { id } = useParams() as { id: string };
+  const router = useRouter();
+  const queryClient = useQueryClient();
+
+  const [title, setTitle] = useState('');
+  const [category, setCategory] = useState('');
+  const [price, setPrice] = useState(0);
+  const [description, setDescription] = useState('');
+  const [address, setAddress] = useState('');
+  const [mainImage, setMainImage] = useState<File | string | null>(null);
+  const [originalSubImages, setOriginalSubImages] = useState<SubImageType[]>(
+    [],
+  );
+  const [subImages, setSubImages] = useState<SubImageType[]>([]);
+  const [originalSchedules, setOriginalSchedules] = useState<Schedule[]>([]);
+  const [dates, setDates] = useState<Schedule[]>([]);
+
+  const { data, isLoading, error } = useQuery<ActivityDetailEdit, Error>({
+    queryKey: ['edit-activity', id],
+    queryFn: async () => {
+      const res = await privateInstance.get(`/activities/${id}`);
+      return res.data;
+    },
+    enabled: !!id,
+  });
+
+  useEffect(() => {
+    if (data) {
+      setTitle(data.title);
+      setCategory(data.category);
+      setPrice(data.price);
+      setDescription(data.description);
+      setAddress(data.address);
+      setMainImage(data.bannerImageUrl);
+
+      const mappedSubImages: SubImageType[] =
+        data.subImages?.map((img) => ({
+          id: img.id,
+          url: img.imageUrl,
+        })) ?? [];
+
+      setOriginalSubImages(mappedSubImages);
+      setSubImages(mappedSubImages);
+
+      setOriginalSchedules(data.schedules ?? []);
+      setDates(data.schedules ?? []);
+    }
+  }, [data]);
+
+  const handleSubImageRemove = (index: number) => {
+    setSubImages((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const handleSubImagesAdd = (newFiles: File[]) => {
+    const remainingSlots = 4 - subImages.length;
+    const filesToAdd = newFiles.slice(0, remainingSlots);
+    const newSubImages = filesToAdd.map((file) => ({ url: file }));
+    setSubImages((prev) => [...prev, ...newSubImages]);
+  };
+
+  const handleAddDate = () => {
+    setDates([...dates, { date: '', startTime: '', endTime: '' }]);
+  };
+
+  const handleRemoveDate = (index: number) => {
+    setDates(dates.filter((_, i) => i !== index));
+  };
+
+  const handleDateChange = (
+    index: number,
+    field: keyof Schedule,
+    value: string,
+  ) => {
+    setDates((prev) =>
+      prev.map((item, i) => (i === index ? { ...item, [field]: value } : item)),
+    );
+  };
+
+  const handleMainImageSelect = (file: File) => {
+    setMainImage(file);
+  };
+
+  const handleMainImageRemove = () => {
+    setMainImage(null);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    try {
+      let bannerImageUrl = '';
+      if (typeof mainImage === 'string') {
+        bannerImageUrl = mainImage;
+      } else if (mainImage instanceof File) {
+        bannerImageUrl = await uploadImage(mainImage);
+      }
+
+      const subImageIdsToRemove = originalSubImages
+        .filter((orig) => !subImages.some((img) => img.id === orig.id))
+        .map((img) => img.id)
+        .filter((id): id is number => id !== undefined);
+
+      const subImageUrlsToAdd: string[] = [];
+
+      for (const img of subImages) {
+        if (!img.id) {
+          if (img.url instanceof File) {
+            const uploadedUrl = await uploadImage(img.url);
+            subImageUrlsToAdd.push(uploadedUrl);
+          } else if (typeof img.url === 'string') {
+            subImageUrlsToAdd.push(img.url);
+          }
+        }
+      }
+
+      const newSchedules = dates.filter((d) => !d.id);
+
+      const scheduleIdsToRemove = originalSchedules
+        .filter((orig) => !dates.some((d) => d.id === orig.id))
+        .map((d) => d.id)
+        .filter((id): id is number => id !== undefined);
+
+      const payload = {
+        title,
+        category,
+        description,
+        address,
+        price,
+        bannerImageUrl,
+        subImageIdsToRemove,
+        subImageUrlsToAdd,
+        schedulesToAdd: newSchedules,
+        scheduleIdsToRemove,
+      };
+
+      await privateInstance.patch(`/editActivity/${id}`, payload);
+
+      alert('수정이 완료되었습니다.'); //토스트로 대체
+      queryClient.invalidateQueries({ queryKey: ['activity', id] });
+      router.push(`/activities/${id}`);
+    } catch (err) {
+      const error = err as AxiosError;
+      const responseData = error.response?.data as
+        | { error?: string; message?: string }
+        | undefined;
+      console.error('전체 에러:', error);
+      alert(
+        //토스트로대체
+        responseData?.error ||
+          responseData?.message ||
+          error.message ||
+          '수정에 실패했습니다.',
+      );
+    }
+  };
+
+  return {
+    title,
+    category,
+    price,
+    description,
+    address,
+    mainImage,
+    subImages,
+    dates,
+    isLoading,
+    error,
+    setTitle,
+    setCategory,
+    setPrice,
+    setDescription,
+    setAddress,
+    handleSubImageRemove,
+    handleSubImagesAdd,
+    handleAddDate,
+    handleRemoveDate,
+    handleDateChange,
+    handleMainImageSelect,
+    handleMainImageRemove,
+    handleSubmit,
+  };
+};

--- a/src/app/(with-header)/myactivity/[id]/page.tsx
+++ b/src/app/(with-header)/myactivity/[id]/page.tsx
@@ -1,0 +1,9 @@
+import EditActivityForm from './components/EditActivityForm';
+
+export default function Page() {
+  return (
+    <div>
+      <EditActivityForm />
+    </div>
+  );
+}

--- a/src/app/(with-header)/myactivity/components/ScheduleSelectForm.tsx
+++ b/src/app/(with-header)/myactivity/components/ScheduleSelectForm.tsx
@@ -1,20 +1,15 @@
 'use client';
 
 import { ScheduleSelect } from './ScheduleSelect';
-
-interface ScheduleType {
-  date: string;
-  startTime: string;
-  endTime: string;
-}
+import { Schedule } from '@/types/activityDetailType';
 
 interface ScheduleSelectFormProps {
-  dates: ScheduleType[];
+  dates: Schedule[];
   onAddDate: () => void;
   onRemoveDate: (index: number) => void;
   onDateChange: (
     index: number,
-    field: keyof ScheduleType,
+    field: keyof Omit<Schedule, 'id'>,
     value: string,
   ) => void;
 }
@@ -39,9 +34,8 @@ export function ScheduleSelectForm({
       </div>
 
       {dates.map((dateSlot, idx) => (
-        <div className='flex'>
+        <div key={dateSlot.id ?? idx} className='flex'>
           <ScheduleSelect
-            key={idx}
             index={idx}
             isRemovable={dates.length > 1}
             onAddDate={onAddDate}

--- a/src/app/api/editActivity/[id]/route.ts
+++ b/src/app/api/editActivity/[id]/route.ts
@@ -1,0 +1,55 @@
+// /app/api/editActivity/[id]/route.ts
+
+import { NextRequest, NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import axios, { AxiosError } from 'axios';
+
+const BACKEND_BASE_URL = process.env.NEXT_PUBLIC_API_SERVER_URL;
+interface ErrorResponse {
+  message?: string;
+  error?: string;
+}
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const id = params.id;
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get('accessToken')?.value;
+
+  if (!accessToken) {
+    return NextResponse.json({ message: '액세스 토큰 없음' }, { status: 401 });
+  }
+
+  try {
+    const body = await req.json();
+
+    const response = await axios.patch(
+      `${BACKEND_BASE_URL}/my-activities/${id}`,
+      body,
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+
+    return NextResponse.json(response.data, { status: 200 });
+  } catch (error: unknown) {
+    console.error('체험 등록 에러:', error);
+
+    if (axios.isAxiosError(error)) {
+      const axiosError = error as AxiosError<ErrorResponse>;
+      const status = axiosError.response?.status || 500;
+      const detail = axiosError.response?.data;
+
+      const errorMessage = detail?.message || detail?.error || '체험 등록 실패';
+
+      return NextResponse.json({ message: errorMessage }, { status });
+    }
+
+    return NextResponse.json({ message: '서버 내부 오류' }, { status: 500 });
+  }
+}

--- a/src/app/api/editActivity/[id]/route.ts
+++ b/src/app/api/editActivity/[id]/route.ts
@@ -1,22 +1,28 @@
-// /app/api/editActivity/[id]/route.ts
-
 import { NextRequest, NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import axios, { AxiosError } from 'axios';
 
 const BACKEND_BASE_URL = process.env.NEXT_PUBLIC_API_SERVER_URL;
+
 interface ErrorResponse {
   message?: string;
   error?: string;
 }
 
-export async function PATCH(
-  req: NextRequest,
-  { params }: { params: { id: string } },
-) {
-  const id = params.id;
+export async function PATCH(req: NextRequest) {
   const cookieStore = await cookies();
   const accessToken = cookieStore.get('accessToken')?.value;
+
+  const url = new URL(req.url); // <- 여기서 전체 URL 접근
+  const segments = url.pathname.split('/');
+  const id = segments[segments.indexOf('editActivity') + 1]; // editActivity 다음 segment가 id임
+
+  if (!id) {
+    return NextResponse.json(
+      { error: '유효하지 않은 요청입니다.' },
+      { status: 400 },
+    );
+  }
 
   if (!accessToken) {
     return NextResponse.json({ message: '액세스 토큰 없음' }, { status: 401 });
@@ -44,7 +50,6 @@ export async function PATCH(
       const axiosError = error as AxiosError<ErrorResponse>;
       const status = axiosError.response?.status || 500;
       const detail = axiosError.response?.data;
-
       const errorMessage = detail?.message || detail?.error || '체험 등록 실패';
 
       return NextResponse.json({ message: errorMessage }, { status });

--- a/src/types/activityDetailType.ts
+++ b/src/types/activityDetailType.ts
@@ -45,7 +45,7 @@ export interface ActivitySubImage {
 
 export interface ActivityDetail {
   id: number;
-  isOwner : boolean;
+  isOwner: boolean;
   userId: number;
   title: string;
   description: string;
@@ -63,4 +63,25 @@ export interface ActivityDetail {
 
 export interface BookinDateProps {
   schedules: ActivitySchedule[];
+}
+
+export interface Schedule {
+  id?: number;
+  date: string;
+  startTime: string;
+  endTime: string;
+}
+
+export interface ActivityDetailEdit {
+  title: string;
+  category: string;
+  description: string;
+  address: string;
+  price: number;
+  bannerImageUrl: string;
+  subImages: {
+    id: number;
+    imageUrl: string;
+  }[];
+  schedules: Schedule[];
 }


### PR DESCRIPTION
## 📌 변경 사항 개요

체험 수정 페이지 api 연결

## 📝 상세 내용

- 내가 작성한 체험상세페이지에서의 드롭다운을 통해 수정페이지 접근가능하도록함
- 수정페이지 로직적용 
- 수정시 다시 체험상세페이지로 이동되도록
- tanstack Query사용

## 🔗 관련 이슈

- #86 

## 🖼️ 스크린샷(선택사항)

<!-- UI 변경이 있는 경우 변경 전/후 스크린샷 -->

## 💡 참고 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 활동 수정 폼 및 페이지가 추가되어 사용자가 활동 정보를 직접 편집할 수 있습니다.
  * 활동 수정 시 이미지, 일정, 세부 정보 등을 변경할 수 있습니다.

* **기능 개선**
  * 활동 상세 페이지에서 "수정하기" 메뉴 선택 시 캐시를 초기화하고, 수정 페이지로 이동하도록 개선되었습니다.
  * 일정 선택 폼이 새로운 타입 정의를 반영하도록 업데이트되었습니다.

* **버그 수정**
  * 일부 타입 정의의 포맷팅 문제가 수정되었습니다.

* **기타**
  * 활동 수정 관련 API가 추가되었습니다.
  * 활동 및 일정 정보를 위한 타입 정의가 확장되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->