### PR TITLE
Feat/91 체험 삭제/체험상세 리뷰 페이지네이션

### DIFF
--- a/src/app/(with-header)/activities/[id]/components/ActivityDetailForm.tsx
+++ b/src/app/(with-header)/activities/[id]/components/ActivityDetailForm.tsx
@@ -7,7 +7,7 @@ import BookingInterface from '@/components/FloatingBox/BookingInterface';
 import LocationMap from '@/components/LocationMap';
 import { useQuery } from '@tanstack/react-query';
 import { privateInstance } from '@/apis/privateInstance';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import useUserStore from '@/stores/authStore';
 import { padMonth } from '../utils/MonthFormatChange';
 import ReviewSection from './ReviewSection';
@@ -73,6 +73,13 @@ export default function ActivityDetailForm() {
     enabled: !!id && !!year && !!month,
   });
 
+  const handleMonthChange = useCallback((year: number, month: number) => {
+    setTimeout(() => {
+      setYear(year);
+      setMonth(month);
+    }, 0);
+  }, []);
+
   if (isLoading || !activityData) {
     return <ActivityDetailSkeleton isOwner={isOwner} />;
   }
@@ -83,7 +90,14 @@ export default function ActivityDetailForm() {
 
   return (
     <div className='mx-auto max-w-1200 p-4 sm:px-20 lg:p-8'>
-      <Title {...activityData} isOwner={isOwner} />
+      <Title
+        title={activityData.title}
+        category={activityData.category}
+        rating={activityData.rating}
+        reviewCount={activityData.reviewCount}
+        address={activityData.address}
+        isOwner={isOwner}
+      />
       <ImageGrid
         mainImage={activityData.bannerImageUrl}
         subImages={subImageUrls}
@@ -105,12 +119,7 @@ export default function ActivityDetailForm() {
           <div className='md:row-span-2'>
             <BookingInterface
               schedules={schedulesData ?? []}
-              onMonthChange={(year, month) => {
-                setTimeout(() => {
-                  setYear(year);
-                  setMonth(month);
-                }, 0);
-              }}
+              onMonthChange={handleMonthChange}
               isOwner={isOwner}
               price={activityData.price}
             />
@@ -121,7 +130,11 @@ export default function ActivityDetailForm() {
           <h2 className='mb-4 pb-2 text-2xl font-bold'>체험 장소</h2>
           <LocationMap address={activityData.address} />
 
-          <ReviewSection activityId={id as string} {...activityData} />
+          <ReviewSection
+            activityId={id as string}
+            reviewCount={activityData.reviewCount}
+            rating={activityData.rating}
+          />
         </div>
       </div>
     </div>

--- a/src/app/(with-header)/activities/[id]/components/ActivityDetailForm.tsx
+++ b/src/app/(with-header)/activities/[id]/components/ActivityDetailForm.tsx
@@ -5,7 +5,6 @@ import Title from './Title';
 import ImageGrid from './ImageGrid';
 import BookingInterface from '@/components/FloatingBox/BookingInterface';
 import LocationMap from '@/components/LocationMap';
-import ReviewTitle from './ReviewTitle';
 import { useQuery } from '@tanstack/react-query';
 import { privateInstance } from '@/apis/privateInstance';
 import { useState, useEffect } from 'react';
@@ -95,7 +94,9 @@ export default function ActivityDetailForm() {
       >
         <div className={`${isOwner ? 'md:col-span-2' : 'md:col-span-2'}`}>
           <h2 className='mb-4 pb-2 text-2xl font-bold'>체험 설명</h2>
-          <p className='whitespace-pre-line'>{activityData.description}</p>
+          <p className='leading-relaxed whitespace-pre-line'>
+            {activityData.description}
+          </p>
         </div>
 
         {!isOwner && (

--- a/src/app/(with-header)/activities/[id]/components/ActivityDetailForm.tsx
+++ b/src/app/(with-header)/activities/[id]/components/ActivityDetailForm.tsx
@@ -12,6 +12,8 @@ import useUserStore from '@/stores/authStore';
 import { padMonth } from '../utils/MonthFormatChange';
 import ReviewSection from './ReviewSection';
 
+import ActivityDetailSkeleton from './ActivityDetailSkeleton';
+
 export default function ActivityDetailForm() {
   const [year, setYear] = useState(2025);
   const [month, setMonth] = useState(7);
@@ -72,7 +74,7 @@ export default function ActivityDetailForm() {
   });
 
   if (isLoading || !activityData) {
-    return <div>로딩 중...</div>;
+    return <ActivityDetailSkeleton isOwner={isOwner} />;
   }
 
   const subImageUrls = activityData.subImages.map(

--- a/src/app/(with-header)/activities/[id]/components/ActivityDetailForm.tsx
+++ b/src/app/(with-header)/activities/[id]/components/ActivityDetailForm.tsx
@@ -7,7 +7,7 @@ import BookingInterface from '@/components/FloatingBox/BookingInterface';
 import LocationMap from '@/components/LocationMap';
 import { useQuery } from '@tanstack/react-query';
 import { privateInstance } from '@/apis/privateInstance';
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 import useUserStore from '@/stores/authStore';
 import { padMonth } from '../utils/MonthFormatChange';
 import ReviewSection from './ReviewSection';

--- a/src/app/(with-header)/activities/[id]/components/ActivityDetailForm.tsx
+++ b/src/app/(with-header)/activities/[id]/components/ActivityDetailForm.tsx
@@ -17,7 +17,6 @@ import ActivityDetailSkeleton from './ActivityDetailSkeleton';
 export default function ActivityDetailForm() {
   const [year, setYear] = useState(2025);
   const [month, setMonth] = useState(7);
-  const [isOwner, setIsOwner] = useState(false);
 
   const { id } = useParams();
 
@@ -30,20 +29,11 @@ export default function ActivityDetailForm() {
     enabled: !!id,
   });
 
-  const userId = activityData?.userId;
-
   const currentUserId = useUserStore((state) =>
     state.user ? state.user.id : null,
   );
-
-  useEffect(() => {
-    if (currentUserId && currentUserId === userId) {
-      setIsOwner(true);
-      console.log('니가 작성한 체험임');
-    } else {
-      setIsOwner(false);
-    }
-  }, [currentUserId, userId]);
+  const userId = activityData?.userId;
+  const isOwner = currentUserId && userId && currentUserId === userId;
 
   const { data: schedulesData } = useQuery({
     queryKey: ['available-schedule', id, year, month],
@@ -77,11 +67,11 @@ export default function ActivityDetailForm() {
     setTimeout(() => {
       setYear(year);
       setMonth(month);
-    }, 0);
+    });
   }, []);
 
   if (isLoading || !activityData) {
-    return <ActivityDetailSkeleton isOwner={isOwner} />;
+    return <ActivityDetailSkeleton userId={activityData?.userId} />;
   }
 
   const subImageUrls = activityData.subImages.map(

--- a/src/app/(with-header)/activities/[id]/components/ActivityDetailForm.tsx
+++ b/src/app/(with-header)/activities/[id]/components/ActivityDetailForm.tsx
@@ -11,6 +11,7 @@ import { privateInstance } from '@/apis/privateInstance';
 import { useState, useEffect } from 'react';
 import useUserStore from '@/stores/authStore';
 import { padMonth } from '../utils/MonthFormatChange';
+import ReviewSection from './ReviewSection';
 
 export default function ActivityDetailForm() {
   const [year, setYear] = useState(2025);
@@ -71,8 +72,6 @@ export default function ActivityDetailForm() {
     enabled: !!id && !!year && !!month,
   });
 
-  
-
   if (isLoading || !activityData) {
     return <div>로딩 중...</div>;
   }
@@ -118,7 +117,8 @@ export default function ActivityDetailForm() {
         <div className={`${isOwner ? 'md:col-span-4' : 'md:col-span-2'}`}>
           <h2 className='mb-4 pb-2 text-2xl font-bold'>체험 장소</h2>
           <LocationMap address={activityData.address} />
-          <ReviewTitle />
+
+          <ReviewSection activityId={id as string} {...activityData} />
         </div>
       </div>
     </div>

--- a/src/app/(with-header)/activities/[id]/components/ActivityDetailSkeleton.tsx
+++ b/src/app/(with-header)/activities/[id]/components/ActivityDetailSkeleton.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import SkeletonBookingInterface from './Skeletons/BookingInterfaceSkeleton';
+
+export default function ActivityDetailSkeleton({
+  isOwner,
+}: {
+  isOwner: boolean;
+}) {
+  return (
+    <div className='mx-auto max-w-1200 animate-pulse p-4 sm:px-20 lg:p-8'>
+      {/* 타이틀부분 */}
+      <div className='mb-6 flex items-start justify-between'>
+        <div className='flex w-full flex-col gap-10'>
+          <div className='h-16 w-24 rounded bg-gray-300' />
+          <div className='h-42 w-3/4 rounded bg-gray-300' />
+          <div className='flex gap-10'>
+            <div className='h-20 w-50 rounded bg-gray-300' />
+            <div className='h-20 w-170 rounded bg-gray-300' />
+          </div>
+        </div>
+        {isOwner && <div className='h-8 w-8 rounded-full bg-gray-300' />}
+      </div>
+
+      {/* 이미지그리드 */}
+      <div className='relative block aspect-square h-[300px] w-full overflow-hidden rounded-lg bg-gray-300 md:hidden' />
+      <div className='hidden h-[500px] grid-cols-4 grid-rows-4 gap-6 md:grid'>
+        <div className='col-span-2 row-span-4 rounded-lg bg-gray-300' />
+        {[...Array(4)].map((_, i) => (
+          <div
+            key={i}
+            className='col-span-1 row-span-2 rounded-lg bg-gray-300'
+          />
+        ))}
+      </div>
+
+      {/* 설명/예약인터페이스/장소 */}
+      <div
+        className={`mt-86 grid gap-10 ${
+          isOwner ? 'md:grid-cols-2' : 'md:grid-cols-3'
+        } grid-cols-1`}
+      >
+        {/* 설명 */}
+        <div className='md:col-span-2'>
+          <div className='mb-10 h-34 w-90 rounded bg-gray-300' />
+          <div className='mb-4 h-180 w-full rounded bg-gray-300' />
+        </div>
+
+        {/* 예약인터페이스 */}
+        {!isOwner && (
+          <div className='md:row-span-2'>
+            <SkeletonBookingInterface />
+          </div>
+        )}
+
+        {/* 체험 장소/리뷰 */}
+        <div
+          className={`${isOwner ? 'md:col-span-4' : 'md:col-span-2'} space-y-8`}
+        >
+          {/* 장소 */}
+          <div>
+            <div className='mb-10 h-34 w-90 rounded bg-gray-300' />
+            <div className='h-[480px] w-full rounded-lg bg-gray-400 shadow-md' />
+            <div className='mt-8 flex items-center space-x-3'>
+              <div className='h-6 w-6 rounded-full bg-gray-300' />
+              <div className='h-5 w-1/2 rounded bg-gray-300' />
+            </div>
+          </div>
+
+          {/* 리뷰 */}
+          <div>
+            <div className='mb-2 h-6 w-24 rounded bg-gray-300' />
+            <div className='mb-4 h-8 w-20 rounded bg-gray-200' />
+            {[...Array(3)].map((_, i) => (
+              <div key={i} className='mb-4 flex gap-4'>
+                <div className='h-10 w-10 rounded-full bg-gray-300' />
+                <div className='flex-1 space-y-2'>
+                  <div className='h-4 w-24 rounded bg-gray-200' />
+                  <div className='h-4 w-full rounded bg-gray-200' />
+                  <div className='h-4 w-3/4 rounded bg-gray-200' />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(with-header)/activities/[id]/components/ActivityDetailSkeleton.tsx
+++ b/src/app/(with-header)/activities/[id]/components/ActivityDetailSkeleton.tsx
@@ -1,15 +1,17 @@
 'use client';
 
 import SkeletonBookingInterface from './Skeletons/BookingInterfaceSkeleton';
+import useUserStore from '@/stores/authStore';
 
-export default function ActivityDetailSkeleton({
-  isOwner,
-}: {
-  isOwner: boolean;
-}) {
+export default function ActivityDetailSkeleton({ userId }: { userId: number }) {
+  const currentUserId = useUserStore((state) => state.user?.id);
+  const isOwner = currentUserId && userId && currentUserId === userId;
+
+  console.log(isOwner);
   return (
     <div className='mx-auto max-w-1200 animate-pulse p-4 sm:px-20 lg:p-8'>
       {/* 타이틀부분 */}
+
       <div className='mb-6 flex items-start justify-between'>
         <div className='flex w-full flex-col gap-10'>
           <div className='h-16 w-24 rounded bg-gray-300' />

--- a/src/app/(with-header)/activities/[id]/components/ReviewCard.tsx
+++ b/src/app/(with-header)/activities/[id]/components/ReviewCard.tsx
@@ -6,6 +6,7 @@ export default function ReviewCard({
   date,
   reviewText,
   avatarSrc,
+  isBlured = false,
 }: ReviewCardProps) {
   return (
     <div className='flex max-w-md justify-start gap-6 p-6 text-black md:max-w-2xl'>
@@ -16,7 +17,11 @@ export default function ReviewCard({
           <p className='text-black'>|</p>
           <p className='text-gray-600'>{date}</p>
         </div>
-        <p className='text-sm leading-relaxed text-black md:text-lg'>
+        <p
+          className={`text-sm leading-relaxed md:text-lg ${
+            isBlured ? 'text-gray-300 select-none' : 'text-black'
+          }`}
+        >
           {reviewText}
         </p>
       </div>

--- a/src/app/(with-header)/activities/[id]/components/ReviewSection.tsx
+++ b/src/app/(with-header)/activities/[id]/components/ReviewSection.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import ReviewCard from './ReviewCard';
 import Pagination from '@/components/Pagination';
 import { useQuery } from '@tanstack/react-query';
 import { privateInstance } from '@/apis/privateInstance';
 import ReviewTitle from './ReviewTitle';
+import useUserStore from '@/stores/authStore';
 
 interface ReviewSectionProps {
   activityId: number;
@@ -20,6 +21,8 @@ export default function ReviewSection({
 }: ReviewSectionProps) {
   const [page, setPage] = useState(1);
   const size = 3;
+
+  const { user } = useUserStore();
 
   const {
     data: reviewData,
@@ -51,29 +54,40 @@ export default function ReviewSection({
   return (
     <div className='mt-10 flex flex-col space-y-8'>
       <ReviewTitle reviewCount={reviewCount} rating={rating} />
-      <div className='min-h-350'>
-        {reviewData.reviews.map((review: any) => (
-          <ReviewCard
-            key={review.id}
-            userName={review.user.nickname}
-            avatarSrc={review.user.profileImageUrl}
-            date={new Date(review.createdAt).toLocaleDateString('ko-KR', {
-              year: 'numeric',
-              month: '2-digit',
-              day: '2-digit',
-            })}
-            reviewText={review.content}
-          />
-        ))}
+
+      <div className='relative min-h-350'>
+        <div className={user ? '' : 'blur-sm'}>
+          {reviewData.reviews.map((review: any) => (
+            <ReviewCard
+              key={review.id}
+              userName={review.user.nickname}
+              avatarSrc={review.user.profileImageUrl}
+              date={new Date(review.createdAt).toLocaleDateString('ko-KR', {
+                year: 'numeric',
+                month: '2-digit',
+                day: '2-digit',
+              })}
+              reviewText={review.content}
+            />
+          ))}
+        </div>
+
+        {!user && (
+          <div className='pointer-events-none absolute inset-0 z-10 flex items-center justify-center'>
+            <div className='rounded-md bg-white/70 px-4 py-2 shadow-md'>
+              <p className='text-sm font-semibold text-gray-700'>
+                로그인 후 리뷰 전체 내용을 확인할 수 있어요.
+              </p>
+            </div>
+          </div>
+        )}
       </div>
 
-      <div>
-        <Pagination
-          currentPage={page}
-          totalPage={Math.ceil(reviewData.totalCount / size)}
-          onPageChange={(newPage) => setPage(newPage)}
-        />
-      </div>
+      <Pagination
+        currentPage={page}
+        totalPage={Math.ceil(reviewData.totalCount / size)}
+        onPageChange={(newPage) => setPage(newPage)}
+      />
     </div>
   );
 }

--- a/src/app/(with-header)/activities/[id]/components/ReviewSection.tsx
+++ b/src/app/(with-header)/activities/[id]/components/ReviewSection.tsx
@@ -76,7 +76,7 @@ export default function ReviewSection({
           <div className='pointer-events-none absolute inset-0 z-10 flex items-center justify-center'>
             <div className='rounded-md bg-white/70 px-4 py-2 shadow-md'>
               <p className='text-sm font-semibold text-gray-700'>
-                로그인 후 리뷰 전체 내용을 확인할 수 있어요.
+                로그인 후 리뷰 전체 내용을 확인할 수 있어요
               </p>
             </div>
           </div>

--- a/src/app/(with-header)/activities/[id]/components/ReviewSection.tsx
+++ b/src/app/(with-header)/activities/[id]/components/ReviewSection.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import ReviewCard from './ReviewCard';
 import Pagination from '@/components/Pagination';
 import { useQuery } from '@tanstack/react-query';
@@ -9,7 +9,7 @@ import ReviewTitle from './ReviewTitle';
 import useUserStore from '@/stores/authStore';
 
 interface ReviewSectionProps {
-  activityId: number;
+  activityId: string;
   reviewCount: number;
   rating: number;
 }
@@ -49,6 +49,22 @@ export default function ReviewSection({
     enabled: !!activityId,
   });
 
+  const ReviewComponent = useCallback(() => {
+    return reviewData?.reviews.map((review: ReviewProps) => (
+      <ReviewCard
+        key={review.id}
+        userName={review.user.nickname}
+        avatarSrc={review.user.profileImageUrl}
+        date={new Date(review.createdAt).toLocaleDateString('ko-KR', {
+          year: 'numeric',
+          month: '2-digit',
+          day: '2-digit',
+        })}
+        reviewText={review.content}
+      />
+    ));
+  }, [reviewData?.reviews]);
+
   if (isLoading) {
     return <p className='mt-4 text-gray-500'>리뷰를 불러오는 중입니다...</p>;
   }
@@ -66,21 +82,7 @@ export default function ReviewSection({
       <ReviewTitle reviewCount={reviewCount} rating={rating} />
 
       <div className='relative min-h-350'>
-        <div className={user ? '' : 'blur-sm'}>
-          {reviewData.reviews.map((review: ReviewProps) => (
-            <ReviewCard
-              key={review.id}
-              userName={review.user.nickname}
-              avatarSrc={review.user.profileImageUrl}
-              date={new Date(review.createdAt).toLocaleDateString('ko-KR', {
-                year: 'numeric',
-                month: '2-digit',
-                day: '2-digit',
-              })}
-              reviewText={review.content}
-            />
-          ))}
-        </div>
+        <div className={user ? '' : 'blur-sm'}>{ReviewComponent()}</div>
 
         {!user && (
           <div className='pointer-events-none absolute inset-0 z-10 flex items-center justify-center'>

--- a/src/app/(with-header)/activities/[id]/components/ReviewSection.tsx
+++ b/src/app/(with-header)/activities/[id]/components/ReviewSection.tsx
@@ -14,6 +14,16 @@ interface ReviewSectionProps {
   rating: number;
 }
 
+interface ReviewProps {
+  id: string;
+  user: {
+    nickname: string;
+    profileImageUrl: string;
+  };
+  createdAt: string;
+  content: string;
+}
+
 export default function ReviewSection({
   activityId,
   reviewCount,
@@ -57,7 +67,7 @@ export default function ReviewSection({
 
       <div className='relative min-h-350'>
         <div className={user ? '' : 'blur-sm'}>
-          {reviewData.reviews.map((review: any) => (
+          {reviewData.reviews.map((review: ReviewProps) => (
             <ReviewCard
               key={review.id}
               userName={review.user.nickname}

--- a/src/app/(with-header)/activities/[id]/components/ReviewSection.tsx
+++ b/src/app/(with-header)/activities/[id]/components/ReviewSection.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import ReviewCard from './ReviewCard';
+import Pagination from '@/components/Pagination';
+import { useQuery } from '@tanstack/react-query';
+import { privateInstance } from '@/apis/privateInstance';
+import ReviewTitle from './ReviewTitle';
+
+interface ReviewSectionProps {
+  activityId: number;
+  reviewCount: number;
+  rating: number;
+}
+
+export default function ReviewSection({
+  activityId,
+  reviewCount,
+  rating,
+}: ReviewSectionProps) {
+  const [page, setPage] = useState(1);
+  const size = 3;
+
+  const {
+    data: reviewData,
+    isLoading,
+    isError,
+  } = useQuery({
+    queryKey: ['reviews', activityId, page],
+    queryFn: async () => {
+      const res = await privateInstance.get(
+        `/activities/${activityId}/review?page=${page}&size=${size}`,
+      );
+      return res.data;
+    },
+    enabled: !!activityId,
+  });
+
+  if (isLoading) {
+    return <p className='mt-4 text-gray-500'>리뷰를 불러오는 중입니다...</p>;
+  }
+
+  if (!reviewData || reviewData.reviews.length === 0) {
+    return <p className='mt-4 text-gray-500'>작성된 리뷰가 없습니다.</p>;
+  }
+
+  if (isError) {
+    throw new Error('에러발생');
+  }
+
+  return (
+    <div className='mt-10 flex flex-col space-y-8'>
+      <ReviewTitle reviewCount={reviewCount} rating={rating} />
+      <div className='min-h-350'>
+        {reviewData.reviews.map((review: any) => (
+          <ReviewCard
+            key={review.id}
+            userName={review.user.nickname}
+            avatarSrc={review.user.profileImageUrl}
+            date={new Date(review.createdAt).toLocaleDateString('ko-KR', {
+              year: 'numeric',
+              month: '2-digit',
+              day: '2-digit',
+            })}
+            reviewText={review.content}
+          />
+        ))}
+      </div>
+
+      <div>
+        <Pagination
+          currentPage={page}
+          totalPage={Math.ceil(reviewData.totalCount / size)}
+          onPageChange={(newPage) => setPage(newPage)}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(with-header)/activities/[id]/components/ReviewTitle.tsx
+++ b/src/app/(with-header)/activities/[id]/components/ReviewTitle.tsx
@@ -1,17 +1,42 @@
-import Star from '@assets/svg/star';
+'use client';
 
-export default function ReviewTitle() {
+import Star from '@assets/svg/star';
+import { useState, useEffect } from 'react';
+
+interface ReviewTitleProps {
+  reviewCount: number;
+  rating: number;
+}
+export default function ReviewTitle({ reviewCount, rating }: ReviewTitleProps) {
+  const [summary, setSummary] = useState('');
+
+  useEffect(() => {
+    const handleSummary = () => {
+      if (rating >= 4.5) {
+        setSummary('매우 만족');
+      } else if (rating >= 3) {
+        setSummary('만족');
+      } else if (rating >= 2.5) {
+        setSummary('보통');
+      } else {
+        setSummary('별로에요');
+      }
+    };
+
+    handleSummary();
+  }, [rating]);
+
   return (
     <div className='mt-10 mb-10 flex flex-col'>
       <h2 className='text-2xl font-bold'>후기</h2>
 
       <div className='mt-15 flex items-center gap-15'>
-        <h2 className='text-4xl font-bold'>4.2</h2>
+        <h2 className='text-4xl font-bold'>{rating}</h2>
         <div className='flex flex-col gap-10'>
-          <p>매우 만족</p>
+          <p>{summary}</p>
           <div className='flex items-center'>
             <Star />
-            <p>1300개 후기</p>
+            <p>{reviewCount}개의 후기</p>
           </div>
         </div>
       </div>

--- a/src/app/(with-header)/activities/[id]/components/ReviewTitle.tsx
+++ b/src/app/(with-header)/activities/[id]/components/ReviewTitle.tsx
@@ -24,7 +24,7 @@ export default function ReviewTitle({ reviewCount, rating }: ReviewTitleProps) {
     };
 
     handleSummary();
-  }, [rating]);
+  }, [reviewCount]);
 
   return (
     <div className='mt-10 mb-10 flex flex-col'>

--- a/src/app/(with-header)/activities/[id]/components/Skeletons/BookingInterfaceSkeleton.tsx
+++ b/src/app/(with-header)/activities/[id]/components/Skeletons/BookingInterfaceSkeleton.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+export default function SkeletonBookingInterface() {
+  return (
+    <div className='w-full max-w-sm'>
+      {/* PC */}
+      <div className='hidden rounded-lg border border-gray-800 bg-white p-6 lg:block'>
+        <div className='flex flex-col gap-10 px-20'>
+          <div className='h-30 w-120 animate-pulse rounded bg-gray-300' />
+          <div className='flex justify-center'>
+            <div className='h-[300px] w-[280px] animate-pulse rounded-lg bg-gray-300' />
+          </div>
+          <div className='h-30 w-180 animate-pulse rounded bg-gray-300' />
+          <div className='h-30 w-80 animate-pulse rounded bg-gray-300' />
+          <div className='h-50 w-full animate-pulse rounded bg-gray-300' />
+          <div className='h-30 w-full animate-pulse rounded bg-gray-300' />
+        </div>
+      </div>
+
+      {/* 태블릿 */}
+      <div className='relative hidden w-full max-w-sm rounded-lg border border-gray-800 bg-white p-6 md:block lg:hidden'>
+        <div className='flex flex-col gap-20 px-18'>
+          <div className='mb-6'>
+            <div className='mb-4 h-6 w-24 animate-pulse rounded bg-gray-200' />
+            <div className='h-12 w-full animate-pulse rounded-lg bg-gray-200' />
+          </div>
+          <div className='flex flex-col items-center justify-center gap-20 px-10'>
+            <div className='h-10 w-28 animate-pulse rounded bg-gray-200' />
+            <div className='h-[300px] w-[280px] animate-pulse rounded-lg bg-gray-200' />
+            <div className='h-12 w-full animate-pulse rounded bg-gray-300' />
+            <div className='h-6 w-24 animate-pulse rounded bg-gray-200' />
+          </div>
+        </div>
+      </div>
+
+      {/* 모바일 */}
+      <div className='fixed right-0 bottom-0 left-0 z-50 block border border-gray-200 bg-white p-6 md:hidden'>
+        <div className='mb-6 flex items-start justify-between'>
+          <div className='flex-1'>
+            <div className='mb-2 h-32 w-60 animate-pulse rounded bg-gray-300' />
+            <div className='mb-4 h-20 w-24 animate-pulse rounded bg-gray-300' />
+            <div className='h-[30px] w-full animate-pulse rounded-lg bg-gray-300' />
+            <div className='mt-4 h-12 w-full animate-pulse rounded bg-gray-300' />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(with-header)/activities/[id]/components/Title.tsx
+++ b/src/app/(with-header)/activities/[id]/components/Title.tsx
@@ -13,6 +13,15 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useDeleteActivity } from '../hooks/useDeleteActivity';
 import Popup from '@/components/Popup';
 
+interface TitleProps {
+  title: string;
+  category: string;
+  rating: number;
+  reviewCount: number;
+  address: string;
+  isOwner: boolean;
+}
+
 export default function Title({
   title,
   category,
@@ -20,7 +29,7 @@ export default function Title({
   reviewCount,
   address,
   isOwner,
-}: ActivityDetail) {
+}: TitleProps) {
   const [isPopupOpen, setIsPopupOpen] = useState(false);
 
   const { id } = useParams();

--- a/src/app/(with-header)/activities/[id]/components/Title.tsx
+++ b/src/app/(with-header)/activities/[id]/components/Title.tsx
@@ -9,6 +9,7 @@ import Trigger from '@/components/ActivityDropdown/trigger';
 import { useParams } from 'next/navigation';
 import { useRouter } from 'next/navigation';
 import { useQueryClient } from '@tanstack/react-query';
+import { useDeleteActivity } from '../hooks/useDeleteActivity';
 
 export default function Title({
   title,
@@ -22,6 +23,14 @@ export default function Title({
   const router = useRouter();
   const queryClient = useQueryClient();
 
+  const { mutate, isError, error } = useDeleteActivity();
+
+  const handleDelete = () => {
+    if (!id) return;
+    if (confirm('정말 삭제하시겠습니까?')) {
+      mutate(id as string);
+    }
+  };
   const handleEdit = () => {
     queryClient.invalidateQueries({ queryKey: ['edit-activity', id] });
     router.push(`/myactivity/${id}`);
@@ -52,7 +61,7 @@ export default function Title({
           </Trigger>
           <Menu>
             <Item onClick={handleEdit}>수정하기</Item>
-            <Item onClick={() => alert('삭제')}>삭제하기</Item>
+            <Item onClick={handleDelete}>삭제하기</Item>
           </Menu>
         </ActivityDropdown>
       )}

--- a/src/app/(with-header)/activities/[id]/components/Title.tsx
+++ b/src/app/(with-header)/activities/[id]/components/Title.tsx
@@ -76,8 +76,6 @@ export default function Title({
         type='confirm'
         onClose={() => setIsPopupOpen(false)}
         onConfirm={handleDeleteConfirm}
-        confirmText='삭제하기'
-        closeText='취소'
       >
         정말 삭제하시겠습니까?
       </Popup>

--- a/src/app/(with-header)/activities/[id]/components/Title.tsx
+++ b/src/app/(with-header)/activities/[id]/components/Title.tsx
@@ -1,4 +1,6 @@
-import React from 'react';
+'use client';
+
+import React, { useState } from 'react';
 import IconDropdown from '@assets/svg/dropdown';
 import Star from '@assets/svg/star';
 import { ActivityDetail } from '@/types/activityDetailType';
@@ -6,10 +8,10 @@ import ActivityDropdown from '@/components/ActivityDropdown';
 import Menu from '@/components/ActivityDropdown/menu';
 import Item from '@/components/ActivityDropdown/Item';
 import Trigger from '@/components/ActivityDropdown/trigger';
-import { useParams } from 'next/navigation';
-import { useRouter } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
 import { useQueryClient } from '@tanstack/react-query';
 import { useDeleteActivity } from '../hooks/useDeleteActivity';
+import Popup from '@/components/Popup';
 
 export default function Title({
   title,
@@ -19,52 +21,66 @@ export default function Title({
   address,
   isOwner,
 }: ActivityDetail) {
+  const [isPopupOpen, setIsPopupOpen] = useState(false);
+
   const { id } = useParams();
   const router = useRouter();
   const queryClient = useQueryClient();
+  const { mutate } = useDeleteActivity();
 
-  const { mutate, isError, error } = useDeleteActivity();
-
-  const handleDelete = () => {
-    if (!id) return;
-    if (confirm('정말 삭제하시겠습니까?')) {
-      mutate(id as string);
-    }
-  };
   const handleEdit = () => {
     queryClient.invalidateQueries({ queryKey: ['edit-activity', id] });
     router.push(`/myactivity/${id}`);
   };
 
+  const handleDeleteConfirm = () => {
+    if (!id) return;
+    mutate(id as string);
+    setIsPopupOpen(false);
+  };
+
   return (
-    <div className='mb-6 flex items-start justify-between'>
-      <div className='flex flex-col gap-8'>
-        <p>{category}</p>
-        <h1 className='mb-2 text-2xl font-bold text-black md:text-3xl'>
-          {title}
-        </h1>
-        <div className='flex items-center gap-10 text-sm text-gray-600'>
-          <div className='flex items-center gap-1'>
-            <Star />
-            <span className='font-medium'>
-              {rating.toFixed(1)} ({reviewCount}명)
-            </span>
+    <>
+      <div className='mb-6 flex items-start justify-between'>
+        <div className='flex flex-col gap-8'>
+          <p>{category}</p>
+          <h1 className='mb-2 text-2xl font-bold text-black md:text-3xl'>
+            {title}
+          </h1>
+          <div className='flex items-center gap-10 text-sm text-gray-600'>
+            <div className='flex items-center gap-1'>
+              <Star />
+              <span className='font-medium'>
+                {rating.toFixed(1)} ({reviewCount}명)
+              </span>
+            </div>
+            <span>{address}</span>
           </div>
-          <span>{address}</span>
         </div>
+
+        {isOwner && (
+          <ActivityDropdown>
+            <Trigger>
+              <IconDropdown />
+            </Trigger>
+            <Menu>
+              <Item onClick={handleEdit}>수정하기</Item>
+              <Item onClick={() => setIsPopupOpen(true)}>삭제하기</Item>
+            </Menu>
+          </ActivityDropdown>
+        )}
       </div>
 
-      {isOwner && (
-        <ActivityDropdown>
-          <Trigger>
-            <IconDropdown />
-          </Trigger>
-          <Menu>
-            <Item onClick={handleEdit}>수정하기</Item>
-            <Item onClick={handleDelete}>삭제하기</Item>
-          </Menu>
-        </ActivityDropdown>
-      )}
-    </div>
+      <Popup
+        isOpen={isPopupOpen}
+        type='confirm'
+        onClose={() => setIsPopupOpen(false)}
+        onConfirm={handleDeleteConfirm}
+        confirmText='삭제하기'
+        closeText='취소'
+      >
+        정말 삭제하시겠습니까?
+      </Popup>
+    </>
   );
 }

--- a/src/app/(with-header)/activities/[id]/components/Title.tsx
+++ b/src/app/(with-header)/activities/[id]/components/Title.tsx
@@ -3,7 +3,6 @@
 import React, { useState } from 'react';
 import IconDropdown from '@assets/svg/dropdown';
 import Star from '@assets/svg/star';
-import { ActivityDetail } from '@/types/activityDetailType';
 import ActivityDropdown from '@/components/ActivityDropdown';
 import Menu from '@/components/ActivityDropdown/menu';
 import Item from '@/components/ActivityDropdown/Item';

--- a/src/app/(with-header)/activities/[id]/hooks/useDeleteActivity.ts
+++ b/src/app/(with-header)/activities/[id]/hooks/useDeleteActivity.ts
@@ -1,0 +1,24 @@
+import { privateInstance } from '@/apis/privateInstance';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+
+const deleteActivity = async (id: string) => {
+  const response = await privateInstance.delete(`/deleteActivity/${id}`);
+  return response.data;
+};
+
+export const useDeleteActivity = () => {
+  const queryClient = useQueryClient();
+  const router = useRouter();
+
+  return useMutation({
+    mutationFn: deleteActivity,
+    onSuccess: (_data, id) => {
+      queryClient.invalidateQueries({ queryKey: ['activity'] });
+      router.push(`/`);
+    },
+    onError: (error) => {
+      console.error('삭제 실패:', error);
+    },
+  });
+};

--- a/src/app/(with-header)/activities/[id]/hooks/useDeleteActivity.ts
+++ b/src/app/(with-header)/activities/[id]/hooks/useDeleteActivity.ts
@@ -14,7 +14,7 @@ export const useDeleteActivity = () => {
 
   return useMutation({
     mutationFn: deleteActivity,
-    onSuccess: (_data, id) => {
+    onSuccess: (_data) => {
       queryClient.invalidateQueries({ queryKey: ['activity'] });
       router.push(`/`);
     },

--- a/src/app/(with-header)/activities/[id]/hooks/useDeleteActivity.ts
+++ b/src/app/(with-header)/activities/[id]/hooks/useDeleteActivity.ts
@@ -1,5 +1,6 @@
 import { privateInstance } from '@/apis/privateInstance';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
 import { useRouter } from 'next/navigation';
 
 const deleteActivity = async (id: string) => {
@@ -17,8 +18,20 @@ export const useDeleteActivity = () => {
       queryClient.invalidateQueries({ queryKey: ['activity'] });
       router.push(`/`);
     },
-    onError: (error) => {
-      console.error('삭제 실패:', error);
+    onError: (error: AxiosError) => {
+      const responseData = error.response?.data as
+        | { error?: string; message?: string }
+        | undefined;
+
+      console.error('전체 에러:', error);
+
+      alert(
+        //토스트로 대체
+        responseData?.error ||
+          responseData?.message ||
+          error.message ||
+          '삭제에 실패했습니다.',
+      );
     },
   });
 };

--- a/src/app/api/activities/[id]/available-schedule/route.ts
+++ b/src/app/api/activities/[id]/available-schedule/route.ts
@@ -1,5 +1,4 @@
 import axios, { AxiosError } from 'axios';
-import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
 
 interface ErrorResponse {

--- a/src/app/api/activities/[id]/available-schedule/route.ts
+++ b/src/app/api/activities/[id]/available-schedule/route.ts
@@ -8,9 +8,6 @@ interface ErrorResponse {
 }
 
 export async function GET(request: NextRequest) {
-  const cookieStore = await cookies();
-  const accessToken = cookieStore.get('accessToken')?.value;
-
   const { searchParams, pathname } = request.nextUrl;
 
   const year = searchParams.get('year');
@@ -29,11 +26,6 @@ export async function GET(request: NextRequest) {
   try {
     const response = await axios.get(
       `${process.env.NEXT_PUBLIC_API_SERVER_URL}/activities/${id}/available-schedule?year=${year}&month=${month}`,
-      {
-        headers: {
-          Authorization: accessToken ? `Bearer ${accessToken}` : undefined,
-        },
-      },
     );
     return NextResponse.json(response.data);
   } catch (err) {

--- a/src/app/api/activities/[id]/review/route.ts
+++ b/src/app/api/activities/[id]/review/route.ts
@@ -1,0 +1,31 @@
+import { ServerErrorResponse } from '@/types/apiErrorResponseType';
+import { NextRequest, NextResponse } from 'next/server';
+import axios from 'axios';
+import { AxiosError } from 'axios';
+
+const BACKEND_BASE_URL = process.env.NEXT_PUBLIC_API_SERVER_URL;
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const { id } = await params;
+  const { searchParams } = new URL(req.url);
+
+  const page = searchParams.get('page') || '1';
+  const size = searchParams.get('size') || '3';
+
+  try {
+    const response = await axios.get(
+      `${BACKEND_BASE_URL}/activities/${id}/reviews?page=${page}&size=${size}`,
+    );
+
+    return NextResponse.json(response.data);
+  } catch (err) {
+    const error = err as AxiosError<ServerErrorResponse>;
+    const message = error.response?.data?.error || '활동 상세 데이터 조회실패';
+    const status = error.response?.status || 500;
+
+    return NextResponse.json({ error: message }, { status });
+  }
+}

--- a/src/app/api/activities/[id]/review/route.ts
+++ b/src/app/api/activities/[id]/review/route.ts
@@ -7,15 +7,17 @@ const BACKEND_BASE_URL = process.env.NEXT_PUBLIC_API_SERVER_URL;
 
 export async function GET(
   req: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
-  const { id } = await params;
   const { searchParams } = new URL(req.url);
 
   const page = searchParams.get('page') || '1';
   const size = searchParams.get('size') || '3';
 
   try {
+    const resolvedParams = await params;
+    const id = resolvedParams.id;
+
     const response = await axios.get(
       `${BACKEND_BASE_URL}/activities/${id}/reviews?page=${page}&size=${size}`,
     );

--- a/src/app/api/activities/[id]/route.ts
+++ b/src/app/api/activities/[id]/route.ts
@@ -8,17 +8,10 @@ export const GET = async (
   { params }: { params: Promise<{ id: string }> },
 ) => {
   const { id } = await params;
-  const cookieStore = await cookies();
-  const accessToken = cookieStore.get('accessToken')?.value;
 
   try {
     const response = await axios.get(
       `${process.env.NEXT_PUBLIC_API_SERVER_URL}/activities/${id}`,
-      {
-        headers: {
-          Authorization: accessToken ? `Bearer ${accessToken}` : undefined,
-        },
-      },
     );
 
     return NextResponse.json(response.data);

--- a/src/app/api/activities/[id]/route.ts
+++ b/src/app/api/activities/[id]/route.ts
@@ -1,5 +1,4 @@
 import axios, { AxiosError } from 'axios';
-import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
 import { ServerErrorResponse } from '@/types/apiErrorResponseType';
 

--- a/src/app/api/addActivity/route.ts
+++ b/src/app/api/addActivity/route.ts
@@ -11,13 +11,16 @@ interface ErrorResponse {
 
 export async function POST(req: NextRequest) {
   const cookieStore = await cookies();
-  const accessToken = cookieStore.get('accessToken')?.value;
-
-  if (!accessToken) {
-    return NextResponse.json({ message: '액세스 토큰 없음' }, { status: 401 });
-  }
 
   try {
+    const accessToken = cookieStore.get('accessToken')?.value;
+
+    if (!accessToken) {
+      return NextResponse.json(
+        { message: '액세스 토큰 없음' },
+        { status: 401 },
+      );
+    }
     const body = await req.json();
     const {
       title,

--- a/src/app/api/deleteActivity/[id]/route.ts
+++ b/src/app/api/deleteActivity/[id]/route.ts
@@ -9,13 +9,13 @@ interface ErrorResponse {
   error?: string;
 }
 
-export async function PATCH(req: NextRequest) {
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const id = params.id;
   const cookieStore = await cookies();
   const accessToken = cookieStore.get('accessToken')?.value;
-
-  const url = new URL(req.url);
-  const segments = url.pathname.split('/');
-  const id = segments[segments.indexOf('editActivity') + 1];
 
   if (!id) {
     return NextResponse.json(
@@ -29,11 +29,9 @@ export async function PATCH(req: NextRequest) {
   }
 
   try {
-    const body = await req.json();
-
-    const response = await axios.patch(
+    const response = await axios.delete(
       `${BACKEND_BASE_URL}/my-activities/${id}`,
-      body,
+
       {
         headers: {
           Authorization: `Bearer ${accessToken}`,
@@ -44,13 +42,13 @@ export async function PATCH(req: NextRequest) {
 
     return NextResponse.json(response.data, { status: 200 });
   } catch (error: unknown) {
-    console.error('체험 등록 에러:', error);
+    console.error('체험 삭제 에러:', error);
 
     if (axios.isAxiosError(error)) {
       const axiosError = error as AxiosError<ErrorResponse>;
       const status = axiosError.response?.status || 500;
       const detail = axiosError.response?.data;
-      const errorMessage = detail?.message || detail?.error || '체험 등록 실패';
+      const errorMessage = detail?.message || detail?.error || '체험 삭제 실패';
 
       return NextResponse.json({ message: errorMessage }, { status });
     }

--- a/src/app/api/deleteActivity/[id]/route.ts
+++ b/src/app/api/deleteActivity/[id]/route.ts
@@ -14,11 +14,11 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> },
 ) {
   const cookieStore = await cookies();
-  const accessToken = cookieStore.get('accessToken')?.value;
 
   try {
     const resolvedParams = await params;
     const id = resolvedParams.id;
+    const accessToken = cookieStore.get('accessToken')?.value;
 
     if (!accessToken) {
       return NextResponse.json(
@@ -26,6 +26,7 @@ export async function DELETE(
         { status: 401 },
       );
     }
+
     const response = await axios.delete(
       `${BACKEND_BASE_URL}/my-activities/${id}`,
 

--- a/src/app/api/deleteActivity/[id]/route.ts
+++ b/src/app/api/deleteActivity/[id]/route.ts
@@ -11,24 +11,21 @@ interface ErrorResponse {
 
 export async function DELETE(
   req: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
-  const id = params.id;
   const cookieStore = await cookies();
   const accessToken = cookieStore.get('accessToken')?.value;
 
-  if (!id) {
-    return NextResponse.json(
-      { error: '유효하지 않은 요청입니다.' },
-      { status: 400 },
-    );
-  }
-
-  if (!accessToken) {
-    return NextResponse.json({ message: '액세스 토큰 없음' }, { status: 401 });
-  }
-
   try {
+    const resolvedParams = await params;
+    const id = resolvedParams.id;
+
+    if (!accessToken) {
+      return NextResponse.json(
+        { message: '액세스 토큰 없음' },
+        { status: 401 },
+      );
+    }
     const response = await axios.delete(
       `${BACKEND_BASE_URL}/my-activities/${id}`,
 

--- a/src/app/api/editActivity/[id]/route.ts
+++ b/src/app/api/editActivity/[id]/route.ts
@@ -14,27 +14,16 @@ export async function PATCH(
   { params }: { params: Promise<{ id: string }> },
 ) {
   const cookieStore = await cookies();
-  const accessToken = cookieStore.get('accessToken')?.value;
-
-  if (!accessToken) {
-    return NextResponse.json(
-      { message: '인증 토큰이 없습니다.' },
-      { status: 401 },
-    );
-  }
 
   try {
     const body = await req.json();
-
-    if (!accessToken) {
-      return NextResponse.json(
-        { message: '액세스 토큰 없음' },
-        { status: 401 },
-      );
-    }
-
     const resolvedParams = await params;
     const id = resolvedParams.id;
+    const accessToken = cookieStore.get('accessToken')?.value;
+
+    if (!accessToken) {
+      return NextResponse.json({ message: '엑세스토큰 없음' }, { status: 401 });
+    }
 
     const response = await axios.patch(
       `${BACKEND_BASE_URL}/my-activities/${id}`,

--- a/src/app/api/editActivity/[id]/route.ts
+++ b/src/app/api/editActivity/[id]/route.ts
@@ -9,27 +9,32 @@ interface ErrorResponse {
   error?: string;
 }
 
-export async function PATCH(req: NextRequest) {
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
   const cookieStore = await cookies();
   const accessToken = cookieStore.get('accessToken')?.value;
 
-  const url = new URL(req.url);
-  const segments = url.pathname.split('/');
-  const id = segments[segments.indexOf('editActivity') + 1];
-
-  if (!id) {
-    return NextResponse.json(
-      { error: '유효하지 않은 요청입니다.' },
-      { status: 400 },
-    );
-  }
-
   if (!accessToken) {
-    return NextResponse.json({ message: '액세스 토큰 없음' }, { status: 401 });
+    return NextResponse.json(
+      { message: '인증 토큰이 없습니다.' },
+      { status: 401 },
+    );
   }
 
   try {
     const body = await req.json();
+
+    if (!accessToken) {
+      return NextResponse.json(
+        { message: '액세스 토큰 없음' },
+        { status: 401 },
+      );
+    }
+
+    const resolvedParams = await params;
+    const id = resolvedParams.id;
 
     const response = await axios.patch(
       `${BACKEND_BASE_URL}/my-activities/${id}`,
@@ -44,13 +49,13 @@ export async function PATCH(req: NextRequest) {
 
     return NextResponse.json(response.data, { status: 200 });
   } catch (error: unknown) {
-    console.error('체험 등록 에러:', error);
+    console.error('체험 수정 에러:', error);
 
     if (axios.isAxiosError(error)) {
       const axiosError = error as AxiosError<ErrorResponse>;
       const status = axiosError.response?.status || 500;
       const detail = axiosError.response?.data;
-      const errorMessage = detail?.message || detail?.error || '체험 등록 실패';
+      const errorMessage = detail?.message || detail?.error || '체험 수정 실패';
 
       return NextResponse.json({ message: errorMessage }, { status });
     }

--- a/src/components/FloatingBox/BookingInterface.tsx
+++ b/src/components/FloatingBox/BookingInterface.tsx
@@ -8,7 +8,6 @@ import TimeSelector from './TimeSelector';
 import TotalPriceDisplay from './TotalPriceDisplay';
 import BookingModal from '@/ui/BookingModal';
 import DatePicker from '../DatePicker/DatePicker';
-import Button from '../Button';
 import { SchedulesProps } from '@/types/activityDetailType';
 import { privateInstance } from '@/apis/privateInstance';
 import { useParams } from 'next/navigation';
@@ -141,14 +140,9 @@ export default function BookingInterface({
               )}
             </div>
             <BookingModal schedules={schedules} price={price} />
-            <Button
-              variant='primary'
-              disabled={!isBookable}
-              className='py-20'
-              onClick={handleBooking}
-            >
+            <BookingButton disabled={!isBookable} onClick={handleBooking}>
               예약하기
-            </Button>
+            </BookingButton>
           </div>
         </div>
       </div>

--- a/src/components/FloatingBox/BookingInterface.tsx
+++ b/src/components/FloatingBox/BookingInterface.tsx
@@ -12,6 +12,7 @@ import { SchedulesProps } from '@/types/activityDetailType';
 import { privateInstance } from '@/apis/privateInstance';
 import { useParams } from 'next/navigation';
 import { AxiosError } from 'axios';
+import useUserStore from '@/stores/authStore';
 
 export default function BookingInterface({
   schedules,
@@ -24,6 +25,8 @@ export default function BookingInterface({
   isOwner: boolean;
   price: number;
 }) {
+  const { user } = useUserStore();
+
   const handleBooking = async () => {
     try {
       await privateInstance.post(`/activities/${id}/reservation`, {
@@ -55,12 +58,20 @@ export default function BookingInterface({
     useBookingStore();
   const { id } = useParams();
 
+  const isLoggedIn = !!user;
   const isBookable =
     !!selectedDate &&
     !!selectedTime &&
     !!selectedTimeId &&
     !!participants &&
-    !isOwner;
+    !isOwner &&
+    isLoggedIn;
+
+  const buttonText = !isLoggedIn
+    ? '로그인이 필요한 기능입니다'
+    : isOwner
+      ? '본인이 등록한 체험입니다'
+      : '예약하기';
 
   return (
     <div className='w-full max-w-sm'>
@@ -74,7 +85,7 @@ export default function BookingInterface({
           <TimeSelector />
           <ParticipantsSelector />
           <BookingButton disabled={!isBookable} onClick={handleBooking}>
-            {isOwner ? '본인이 등록한 체험입니다' : '예약하기'}
+            {buttonText}
           </BookingButton>
           <TotalPriceDisplay price={price} />
         </div>
@@ -107,7 +118,7 @@ export default function BookingInterface({
             <BookingModal schedules={schedules} price={price} />
 
             <BookingButton disabled={!isBookable} onClick={handleBooking}>
-              {isOwner ? '본인이 등록한 체험입니다' : '예약하기'}
+              {buttonText}
             </BookingButton>
             <TotalPriceDisplay price={price} />
           </div>
@@ -141,7 +152,7 @@ export default function BookingInterface({
             </div>
             <BookingModal schedules={schedules} price={price} />
             <BookingButton disabled={!isBookable} onClick={handleBooking}>
-              예약하기
+              {buttonText}
             </BookingButton>
           </div>
         </div>

--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -39,6 +39,8 @@ export default function Popup({
   children,
   onClose,
   onConfirm,
+  closeText,
+  confirmText,
 }: PopupProps) {
   const popupRef = useRef<HTMLDivElement>(null);
   useOutsideClick(popupRef, onClose);
@@ -90,14 +92,14 @@ export default function Popup({
               className={cn('w-80 rounded-md')}
               onClick={onClose}
             >
-              아니오
+              {closeText}
             </Button>
             <Button
               variant='primary'
               className={cn('w-80 rounded-md')}
               onClick={onConfirm}
             >
-              취소하기
+              {confirmText}
             </Button>
           </div>
         </div>

--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -39,8 +39,6 @@ export default function Popup({
   children,
   onClose,
   onConfirm,
-  closeText,
-  confirmText,
 }: PopupProps) {
   const popupRef = useRef<HTMLDivElement>(null);
   useOutsideClick(popupRef, onClose);
@@ -92,14 +90,14 @@ export default function Popup({
               className={cn('w-80 rounded-md')}
               onClick={onClose}
             >
-              {closeText}
+              아니요
             </Button>
             <Button
               variant='primary'
               className={cn('w-80 rounded-md')}
               onClick={onConfirm}
             >
-              {confirmText}
+              예
             </Button>
           </div>
         </div>

--- a/src/types/activityDetailType.ts
+++ b/src/types/activityDetailType.ts
@@ -8,6 +8,7 @@ export interface ReviewCardProps {
   date: string;
   reviewText: string;
   avatarSrc: string;
+  isBlured?: boolean;
 }
 
 export interface TitleProps {

--- a/src/types/popupTypes.ts
+++ b/src/types/popupTypes.ts
@@ -18,6 +18,8 @@ type PopupType = 'alert' | 'confirm';
 
 export interface PopupProps {
   isOpen: boolean;
+  closeText: string;
+  confirmText: string;
   type: PopupType;
   children: ReactNode;
   onClose: () => void;

--- a/src/types/popupTypes.ts
+++ b/src/types/popupTypes.ts
@@ -18,8 +18,6 @@ type PopupType = 'alert' | 'confirm';
 
 export interface PopupProps {
   isOpen: boolean;
-  closeText: string;
-  confirmText: string;
   type: PopupType;
   children: ReactNode;
   onClose: () => void;


### PR DESCRIPTION
## 📌 변경 사항 개요

- 체험 삭제/체험상세페이지네이션

## 📝 상세 내용

- 체험삭제 로직 구현
- 체험상세 리뷰  페이지네이션 구현
- 비로그인시 리뷰들 블러처리
- 체험 상세페이지 스켈레톤 적용

## 🔗 관련 이슈

- #91 

## 🖼️ 스크린샷(선택사항)

<img width="1352" height="583" alt="df" src="https://github.com/user-attachments/assets/fb4e6954-f7b8-4c11-ad2e-1b1076addccb" />


<img width="755" height="575" alt="zxcvzxcvxcvcv" src="https://github.com/user-attachments/assets/aaafb1aa-4d37-4a3b-8a3e-cb2da5560318" />


## 💡 참고 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **신규 기능**
  * 활동 상세 페이지에 리뷰 섹션이 추가되어, 리뷰 목록과 평점, 페이지네이션을 통해 리뷰를 확인할 수 있습니다.
  * 비로그인 사용자는 리뷰 내용이 흐릿하게 표시되며, 로그인 시 전체 내용을 볼 수 있습니다.
  * 활동 삭제 시 확인 팝업이 제공되어, 실수로 삭제하는 것을 방지할 수 있습니다.
  * 활동 상세 페이지 로딩 시 스켈레톤 UI가 적용되어 사용자 경험이 향상되었습니다.
  * 예약 인터페이스에 다양한 기기별 스켈레톤 UI가 추가되었습니다.

* **버그 수정 및 개선**
  * 리뷰 제목 컴포넌트가 동적으로 리뷰 수와 평점을 반영하도록 개선되었습니다.
  * 활동 삭제 및 수정 API가 보다 안정적으로 동작하도록 개선되었습니다.
  * 팝업 버튼의 문구가 자연스럽게 수정되었습니다.
  * 리뷰 카드의 텍스트 색상과 선택 가능 여부가 상태에 따라 동적으로 변경됩니다.
  * 모바일 예약 인터페이스에서 버튼 컴포넌트가 개선되었습니다.
  * 활동 설명 텍스트의 가독성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->