### PR TITLE
Fix/109 빌드 시점에 환경 변수를 주입하여 API 경로 오류 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,6 +74,10 @@ jobs:
           # 빌드할 플랫폼 지정
           platforms: linux/amd64
 
+          # 모든 환경 변수를 하나의 build-arg로 전달
+          build-args: |
+            BUILD_ENV_VARS=${{ format('NEXT_PUBLIC_API_URL={0} NEXT_PUBLIC_API_SERVER_URL={1} NEXT_PUBLIC_KAKAO_CLIENT_ID={2} NEXT_PUBLIC_KAKAO_APP_JS_KEY={3} NEXT_PUBLIC_SITE_URL={4} NEXT_PUBLIC_KAKAO_SIGNIN_REDIRECT_URL={5} NEXT_PUBLIC_KAKAO_SIGNUP_REDIRECT_URL={6}', secrets.NEXT_PUBLIC_API_URL, secrets.NEXT_PUBLIC_API_SERVER_URL, secrets.NEXT_PUBLIC_KAKAO_CLIENT_ID, secrets.NEXT_PUBLIC_KAKAO_APP_JS_KEY, secrets.NEXT_PUBLIC_SITE_URL, secrets.NEXT_PUBLIC_KAKAO_SIGNIN_REDIRECT_URL, secrets.NEXT_PUBLIC_KAKAO_SIGNUP_REDIRECT_URL) }}
+
   # Job 2: OCI 서버에 배포
   deploy:
     name: Deploy to OCI Server

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,12 @@ RUN corepack prepare pnpm@latest --activate
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
+# 빌드 시점에 주입될 환경 변수 선언
+ARG BUILD_ENV_VARS
+
+# 전달받은 ARG 환경 변수를 .env.production 파일에 저장
+RUN echo "$BUILD_ENV_VARS" | tr ' ' '\n' > .env.production
+
 # Next.js 빌드
 ENV NEXT_TELEMETRY_DISABLED 1
 RUN pnpm build


### PR DESCRIPTION
## 📌 변경 사항 개요
Docker 이미지 빌드 시점에 환경 변수가 누락되어 발생하던 APi 경로 오류
<!-- 이 PR에서 수행한 변경 사항에 대한 간략한 설명 -->

## 📝 상세 내용
- builder 스테이지에 ARG와 ENV 추가 -> 빌드 시점에 외부에서 환경 변수를 주입받을 수 있도록 변경
- build job의 docker/build-push-action 단계에 build-args 옵션을 추가 -> 깃허브 시크릿을 빌드 인자로 전달하도록 수정
<!-- 구현 내용에 대한 자세한 설명 -->

## 🔗 관련 이슈
- Resolves #109 
<!-- 관련된 이슈 번호 (예: Resolves: #123) -->

## 🖼️ 스크린샷(선택사항)

<!-- UI 변경이 있는 경우 변경 전/후 스크린샷 -->

## 💡 참고 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Docker 이미지 빌드 시 환경 변수들이 하나의 인자로 전달되어 `.env.production` 파일에 저장되도록 변경되었습니다. 이로 인해 배포 환경 설정이 더욱 일관되고 간편해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->